### PR TITLE
Add fields to allow the project owner to change bank account information

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -53,9 +53,7 @@ class ProjectsController < ApplicationController
     options.merge!(channels: [channel]) if channel
 
     if channel && channel.recurring?
-      pagarme_recipient = PagarmeService.create_recipient({
-        bank_account: params[:bank_account]
-      })
+      pagarme_recipient = PagarmeService.create_recipient(params[:bank_account])
 
       options.merge!(recipient: pagarme_recipient['id'])
     end
@@ -88,7 +86,7 @@ class ProjectsController < ApplicationController
       update_project_images_and_partners(permitted_params)
 
       if channel && channel.recurring?
-        PagarmeService.update_recipient(@project.recipient, params[:bank_account])
+        PagarmeService.update_recipient_bank_account(@project.recipient, params[:bank_account])
       end
 
       format.html do

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -54,9 +54,6 @@ class ProjectsController < ApplicationController
 
     if channel && channel.recurring?
       pagarme_recipient = PagarmeService.create_recipient({
-        transfer_interval: 'monthly',
-        transfer_day: Time.current.day,
-        transfer_enabled: true,
         bank_account: params[:bank_account]
       })
 
@@ -89,6 +86,11 @@ class ProjectsController < ApplicationController
     authorize resource
     update! do |format|
       update_project_images_and_partners(permitted_params)
+
+      if channel && channel.recurring?
+        PagarmeService.update_recipient(@project.recipient, params[:bank_account])
+      end
+
       format.html do
         if resource.errors.present?
           flash[:alert] = resource.errors.full_messages.to_sentence
@@ -117,7 +119,12 @@ class ProjectsController < ApplicationController
     @contributions = @project.contributions.available_to_count
     @pending_contributions = @project.contributions.with_state(:waiting_confirmation)
 
-    unless @channel && @channel.recurring?
+    if @channel && @channel.recurring?
+      @banks = Bank.to_collection
+
+      recipient = PagarmeService.find_recipient_by_id(@project.recipient)
+      @bank_account = recipient.bank_account
+    else
       @color = (channel.present? && channel.main_color) || @project.category.color
     end
   end

--- a/app/services/pagarme_service.rb
+++ b/app/services/pagarme_service.rb
@@ -1,5 +1,7 @@
 class PagarmeService
-  def self.create_recipient(recipient)
+  def self.create_recipient(bank_account)
+    recipient = recipient_params(bank_account)
+
     request = PagarMe::Request.new('/recipients', 'POST')
     request.parameters = recipient
 
@@ -10,5 +12,25 @@ class PagarmeService
     request = PagarMe::Request.new('/recipients' + "/#{id}", 'GET')
     response = request.run
     PagarMe::Util.convert_to_pagarme_object(response)
+  end
+
+  def self.update_recipient(id, bank_account)
+    request = PagarMe::Request.new('/recipients' + "/#{id}", 'PUT')
+    request.parameters = {bank_account: bank_account}
+    response = request.run
+
+    PagarMe::Util.convert_to_pagarme_object(response)
+  end
+
+  private
+
+  def self.recipient_params(bank_account)
+    recipient = {
+      transfer_interval: 'monthly',
+      transfer_day: Time.current.day,
+      transfer_enabled: true,
+    }
+
+    recipient.merge(bank_account: bank_account)
   end
 end

--- a/app/services/pagarme_service.rb
+++ b/app/services/pagarme_service.rb
@@ -1,6 +1,6 @@
 class PagarmeService
-  def self.create_recipient(bank_account)
-    recipient = recipient_params(bank_account)
+  def self.create_recipient(account_info)
+    recipient = recipient_params(account_info)
 
     request = PagarMe::Request.new('/recipients', 'POST')
     request.parameters = recipient
@@ -14,9 +14,11 @@ class PagarmeService
     PagarMe::Util.convert_to_pagarme_object(response)
   end
 
-  def self.update_recipient(id, bank_account)
+  def self.update_recipient_bank_account(id, account_info)
+    bank_account_id = create_bank_account(account_info)
+
     request = PagarMe::Request.new('/recipients' + "/#{id}", 'PUT')
-    request.parameters = {bank_account: bank_account}
+    request.parameters = {bank_account_id: bank_account_id}
     response = request.run
 
     PagarMe::Util.convert_to_pagarme_object(response)

--- a/app/services/pagarme_service.rb
+++ b/app/services/pagarme_service.rb
@@ -22,6 +22,12 @@ class PagarmeService
     PagarMe::Util.convert_to_pagarme_object(response)
   end
 
+  def self.create_bank_account(account_info)
+    bank_account = PagarMe::BankAccount.new(account_info).create
+
+    bank_account["id"]
+  end
+
   private
 
   def self.recipient_params(bank_account)

--- a/app/views/juntos_bootstrap/projects/_project_basics.html.slim
+++ b/app/views/juntos_bootstrap/projects/_project_basics.html.slim
@@ -89,6 +89,59 @@
                       .w-col.w-col-4.w-col-small-6.w-col-tiny-6.text-field.postfix.no-hover
                         .fontcolor-secondary.u-text-center.fontsize-base.lineheight-tightest Dias
 
+              - if channel && channel.recurring?
+                p.fontsize-large = t('activerecord.models.bank_account')
+
+                .u-marginbottom-40
+                  = form.input :bank,
+                    label: t('activerecord.attributes.bank_account.bank') do
+                    = select_tag 'bank_account[bank_code]',
+                      options_for_select(@banks, @bank_account.bank_code),
+                      class: 'select required w-input text-field',
+                      prompt: t('simple_form.prompts.project.select'),
+                      required: true
+
+                .u-marginbottom-40
+                  = form.input :agency,
+                    label: t('activerecord.attributes.bank_account.agency') do
+                    = text_field_tag 'bank_account[agencia]',
+                      @bank_account.agencia, required: true,
+                      class: 'text required w-input text-field'
+
+                .u-marginbottom-40
+                  = form.input :agency_digit,
+                    label: t('activerecord.attributes.bank_account.agency_digit') do
+                    = text_field_tag 'bank_account[agencia_dv]',
+                      @bank_account.agencia_dv, maxlength: 2,
+                      class: 'text optional w-input text-field'
+
+                .u-marginbottom-40
+                  = form.input :account,
+                    label: t('activerecord.attributes.bank_account.account') do
+                    = text_field_tag 'bank_account[conta]', @bank_account.conta,
+                      class: 'text required w-input text-field', required: true
+
+                .u-marginbottom-40
+                  = form.input :account_digit,
+                    label: t('activerecord.attributes.bank_account.account_digit') do
+                    = text_field_tag 'bank_account[conta_dv]',
+                      @bank_account.conta_dv, required: true, maxlength: 2,
+                      class: 'text required w-input text-field'
+
+                .u-marginbottom-40
+                  = form.input :owner_name,
+                    label: t('activerecord.attributes.bank_account.owner_name') do
+                    = text_field_tag 'bank_account[legal_name]',
+                      @bank_account.legal_name, required: true,
+                      class: 'text required w-input text-field'
+
+                .u-marginbottom-40
+                  = form.input :owner_document,
+                    label: t('activerecord.attributes.bank_account.owner_document') do
+                    = text_field_tag 'bank_account[document_number]',
+                      @bank_account.document_number, required: true,
+                      class: 'text required w-input text-field'
+
         .w-col.w-col-4
           .w-hidden-main.w-hidden-medium.card.u-radius.card-notification.zindex-20
             .u-marginbottom-20.fontsize-base.fontweight-bold Painel de controle

--- a/app/views/juntos_bootstrap/projects/_project_basics.html.slim
+++ b/app/views/juntos_bootstrap/projects/_project_basics.html.slim
@@ -138,9 +138,11 @@
                 .u-marginbottom-40
                   = form.input :owner_document,
                     label: t('activerecord.attributes.bank_account.owner_document') do
-                    = text_field_tag 'bank_account[document_number]',
-                      @bank_account.document_number, required: true,
+                    = text_field_tag 'bank_account[owner_document]',
+                      @bank_account.document_number, disabled: true,
                       class: 'text required w-input text-field'
+                    = hidden_field_tag 'bank_account[document_number]',
+                      @bank_account.document_number
 
         .w-col.w-col-4
           .w-hidden-main.w-hidden-medium.card.u-radius.card-notification.zindex-20

--- a/spec/services/pagarme_service_spec.rb
+++ b/spec/services/pagarme_service_spec.rb
@@ -8,21 +8,23 @@ RSpec.describe PagarmeService do
   end
 
   describe '.create_recipient' do
-    let(:recipient) {{
-      transfer_interval: 'monthly',
-      transfer_day: 7,
-      transfer_enabled: true,
-      bank_account: {
-        bank_code: '001',
-        agencia: '0001',
-        conta: '000001',
-        conta_dv: '00',
-        document_number: '111.111.111-11',
-        legal_name: 'Juntos com você API'
-      }
+    let(:bank_account) {{
+      bank_code: '001',
+      agencia: '0001',
+      conta: '000001',
+      conta_dv: '00',
+      document_number: '111.111.111-11',
+      legal_name: 'Juntos com você API'
     }}
 
-    subject { described_class.create_recipient(recipient) }
+    let(:recipient) {{
+      transfer_interval: 'monthly',
+      transfer_day: Time.current.day,
+      transfer_enabled: true,
+      bank_account: bank_account
+    }}
+
+    subject { described_class.create_recipient(bank_account) }
 
     before do
       allow(request).to receive_messages(:parameters= => nil, :run => nil)

--- a/spec/services/pagarme_service_spec.rb
+++ b/spec/services/pagarme_service_spec.rb
@@ -1,103 +1,142 @@
 require 'rails_helper'
 
 RSpec.describe PagarmeService do
-  let(:request) { instance_double('PagarMe::Request') }
+  describe 'operations with Request class' do
+    let(:request) { instance_double('PagarMe::Request') }
 
-  before do
-    allow(PagarMe::Request).to receive(:new).and_return(request)
+    before do
+      allow(PagarMe::Request).to receive(:new).and_return(request)
+    end
+
+    describe '.create_recipient' do
+      let(:bank_account) {{
+        bank_code: '001',
+        agencia: '0001',
+        conta: '000001',
+        conta_dv: '00',
+        document_number: '111.111.111-11',
+        legal_name: 'Juntos com você API'
+      }}
+
+      let(:recipient) {{
+        transfer_interval: 'monthly',
+        transfer_day: Time.current.day,
+        transfer_enabled: true,
+        bank_account: bank_account
+      }}
+
+      subject { described_class.create_recipient(bank_account) }
+
+      before do
+        allow(request).to receive_messages(:parameters= => nil, :run => nil)
+      end
+
+      it 'instantiates a new Request object' do
+        expect(PagarMe::Request).to receive(:new).with('/recipients', 'POST')
+
+        subject
+      end
+
+      it 'passes the correct parameters to the request' do
+        expect(request).to receive(:parameters=).with(recipient)
+
+        subject
+      end
+
+      it 'triggers the request' do
+        expect(request).to receive(:run)
+
+        subject
+      end
+    end
+
+    describe '.find_recipient_by_id' do
+      let(:recipient_response) {{
+        "object" => "recipient",
+        "id" => "re_ciknzf3jp003eyn6erpmwarkk",
+        "bank_account" => {
+          "object" => "bank_account",
+          "id" => 11445923,
+          "bank_code" => "033",
+          "agencia" => "2345",
+          "agencia_dv" => "1",
+          "conta" => "0123456",
+          "conta_dv" => "7",
+          "document_type" => "cnpj",
+          "document_number" => "12275141000104",
+          "legal_name" => "ADMIN",
+          "charge_transfer_fees" => true,
+          "date_created" => "2016-02-15T12:53:33.000Z"
+        },
+        "transfer_enabled" => true,
+        "last_transfer" => nil,
+        "transfer_interval" => "monthly",
+        "transfer_day" => 15,
+        "automatic_anticipation_enabled" => false,
+        "anticipatable_volume_percentage" => 0,
+        "date_created" => "2016-02-15T12:53:33.000Z",
+        "date_updated" => "2016-02-15T12:53:33.000Z"
+      }}
+
+      let!(:recipient_object) {
+        PagarMe::Util.convert_to_pagarme_object(recipient_response)
+      }
+
+      subject { described_class.find_recipient_by_id(recipient_object.id) }
+
+      before do
+        allow(request).to receive_messages(run: recipient_response)
+      end
+
+      it 'instantiates a new Request object' do
+        expect(PagarMe::Request)
+          .to receive(:new).with('/recipients/' +recipient_object.id, 'GET')
+
+        subject
+      end
+
+      it 'triggers the request' do
+        expect(request).to receive(:run)
+
+        subject
+      end
+    end
   end
 
-  describe '.create_recipient' do
+  describe 'create_bank_account' do
+    let(:account_instance) { instance_double('PagarMe::BankAccount') }
     let(:bank_account) {{
-      bank_code: '001',
-      agencia: '0001',
-      conta: '000001',
-      conta_dv: '00',
-      document_number: '111.111.111-11',
-      legal_name: 'Juntos com você API'
+      'object' => 'bank_account',
+      'id' => 11585644,
+      'document_type' => 'cpf',
+      'charge_transfer_fees' => true,
+      'date_created' => '2016-02-22T14:49:49.000Z'
+    }.merge(account_info)}
+
+    let(:account_info) {{
+      'bank_code' => '341',
+      'agencia' => '007',
+      'agencia_dv' => nil,
+      'conta' => '077',
+      'conta_dv' => 77,
+      'document_number' => '74458396820',
+      'legal_name' => 'TEST BANK ACCOUNT',
     }}
 
-    let(:recipient) {{
-      transfer_interval: 'monthly',
-      transfer_day: Time.current.day,
-      transfer_enabled: true,
-      bank_account: bank_account
-    }}
-
-    subject { described_class.create_recipient(bank_account) }
+    subject { described_class.create_bank_account account_info }
 
     before do
-      allow(request).to receive_messages(:parameters= => nil, :run => nil)
+      allow(PagarMe::BankAccount).to receive(:new).and_return(account_instance)
+      allow(account_instance).to receive(:create).and_return(bank_account)
     end
 
-    it 'instantiates a new Request object' do
-      expect(PagarMe::Request).to receive(:new).with('/recipients', 'POST')
+    it 'pass the account information as an argument to a new bank account' do
+      expect(PagarMe::BankAccount).to receive(:new).with(account_info)
 
       subject
     end
 
-    it 'passes the correct parameters to the request' do
-      expect(request).to receive(:parameters=).with(recipient)
+    it { is_expected.to eq bank_account['id'] }
 
-      subject
-    end
-
-    it 'triggers the request' do
-      expect(request).to receive(:run)
-
-      subject
-    end
-  end
-
-  describe '.find_recipient_by_id' do
-    let(:recipient_response) {{
-      "object" => "recipient",
-      "id" => "re_ciknzf3jp003eyn6erpmwarkk",
-      "bank_account" => {
-        "object" => "bank_account",
-        "id" => 11445923,
-        "bank_code" => "033",
-        "agencia" => "2345",
-        "agencia_dv" => "1",
-        "conta" => "0123456",
-        "conta_dv" => "7",
-        "document_type" => "cnpj",
-        "document_number" => "12275141000104",
-        "legal_name" => "ADMIN",
-        "charge_transfer_fees" => true,
-        "date_created" => "2016-02-15T12:53:33.000Z"
-      },
-      "transfer_enabled" => true,
-      "last_transfer" => nil,
-      "transfer_interval" => "monthly",
-      "transfer_day" => 15,
-      "automatic_anticipation_enabled" => false,
-      "anticipatable_volume_percentage" => 0,
-      "date_created" => "2016-02-15T12:53:33.000Z",
-      "date_updated" => "2016-02-15T12:53:33.000Z"
-    }}
-
-    let!(:recipient_object) {
-      PagarMe::Util.convert_to_pagarme_object(recipient_response)
-    }
-
-    subject { described_class.find_recipient_by_id(recipient_object.id) }
-
-    before do
-      allow(request).to receive_messages(run: recipient_response)
-    end
-
-    it 'instantiates a new Request object' do
-      expect(PagarMe::Request)
-        .to receive(:new).with('/recipients/' +recipient_object.id, 'GET')
-
-      subject
-    end
-
-    it 'triggers the request' do
-      expect(request).to receive(:run)
-
-      subject
-    end
   end
 end

--- a/spec/services/pagarme_service_spec.rb
+++ b/spec/services/pagarme_service_spec.rb
@@ -101,6 +101,50 @@ RSpec.describe PagarmeService do
         subject
       end
     end
+
+    describe '.update_recipient_bank_account' do
+      let(:recipient_id) { 're_ciknzf3jp003eyn6erpmwarkk' }
+      let(:bank_account_id) { 11585644 }
+      let(:account_info) {{
+        'bank_code' => '341',
+        'agencia' => '007',
+        'agencia_dv' => nil,
+        'conta' => '077',
+        'conta_dv' => 77,
+        'document_number' => '74458396820',
+        'legal_name' => 'TEST BANK ACCOUNT',
+      }}
+
+      subject {
+        described_class.update_recipient_bank_account recipient_id, account_info
+      }
+
+      before do
+        allow(request).to receive_messages(:parameters= => nil, :run => nil)
+        allow(PagarmeService).to receive(:create_bank_account)
+                                        .and_return(bank_account_id)
+      end
+
+      it 'instantiates a new Request object' do
+        expect(PagarMe::Request)
+          .to receive(:new).with('/recipients/' +recipient_id, 'PUT')
+
+        subject
+      end
+
+      it 'passes the correct parameters to the request' do
+        expect(request)
+          .to receive(:parameters=).with(bank_account_id: bank_account_id)
+
+        subject
+      end
+
+      it 'triggers the request' do
+        expect(request).to receive(:run)
+
+        subject
+      end
+    end
   end
 
   describe 'create_bank_account' do


### PR DESCRIPTION
According to [Pagar.me](https://pagar.me) docs, it's not possible to change the `document_number` option while updating bank account information.