### PR TITLE
Disable bank account fields when there is a job running in background

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -78,7 +78,7 @@ class ProjectsController < ApplicationController
     update! do |format|
       update_project_images_and_partners(permitted_params)
 
-      if channel && channel.recurring?
+      if channel && channel.recurring? && params[:bank_account]
         RecipientWorker.perform_async(@project.id, params[:bank_account])
       end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -79,7 +79,7 @@ class ProjectsController < ApplicationController
       update_project_images_and_partners(permitted_params)
 
       if channel && channel.recurring?
-        PagarmeService.delay.process(@project, params[:bank_account])
+        RecipientWorker.perform_async(@project.id, params[:bank_account])
       end
 
       format.html do

--- a/app/services/pagarme_service.rb
+++ b/app/services/pagarme_service.rb
@@ -1,11 +1,15 @@
 class PagarmeService
-  def self.process(project, account_info)
+  def self.process(project_id, account_info)
+    project = Project.find(project_id)
+
     if project.recipient
       update_recipient_bank_account(project.recipient, account_info)
     else
       recipient = create_recipient(account_info)
       project.update_attributes(recipient: recipient['id'])
     end
+
+    project.update_attributes(recipient_job_running: false)
   end
 
   def self.create_recipient(account_info)

--- a/app/views/juntos_bootstrap/projects/_project_basics.html.slim
+++ b/app/views/juntos_bootstrap/projects/_project_basics.html.slim
@@ -92,58 +92,66 @@
               - if channel && channel.recurring?
                 p.fontsize-large = t('activerecord.models.bank_account')
 
-                .u-marginbottom-40
-                  = form.input :bank,
-                    label: t('activerecord.attributes.bank_account.bank') do
-                    = select_tag 'bank_account[bank_code]',
-                      options_for_select(@banks, @bank_account.bank_code),
-                      class: 'select required w-input text-field',
-                      prompt: t('simple_form.prompts.project.select'),
-                      required: true
+                fieldset[disabled=@project.recipient_job_running?]
+                  - if @project.recipient_job_running?
+                    .card.card-waiting.u-radius.zindex-10.u-marginbottom-30
+                      .fontsize-smaller.fontweight-bold.u-marginbottom-10
+                        = t('.bank_account_job_running_title')
+                      .fontsize-smaller = t('.bank_account_job_running')
 
-                .u-marginbottom-40
-                  = form.input :agency,
-                    label: t('activerecord.attributes.bank_account.agency') do
-                    = text_field_tag 'bank_account[agencia]',
-                      @bank_account.agencia, required: true, maxlength: 5,
-                      class: 'text required w-input text-field'
+                  .u-marginbottom-40
+                    = form.input :bank,
+                      label: t('activerecord.attributes.bank_account.bank') do
+                      = select_tag 'bank_account[bank_code]',
+                        options_for_select(@banks, @bank_account.bank_code),
+                        class: 'select required w-input text-field',
+                        prompt: t('simple_form.prompts.project.select'),
+                        required: true
 
-                .u-marginbottom-40
-                  = form.input :agency_digit,
-                    label: t('activerecord.attributes.bank_account.agency_digit') do
-                    = text_field_tag 'bank_account[agencia_dv]',
-                      @bank_account.agencia_dv, maxlength: 2,
-                      class: 'text optional w-input text-field'
+                  .u-marginbottom-40
+                    = form.input :agency,
+                      label: t('activerecord.attributes.bank_account.agency') do
+                      = text_field_tag 'bank_account[agencia]',
+                        @bank_account.agencia, required: true, maxlength: 5,
+                        class: 'text required w-input text-field'
 
-                .u-marginbottom-40
-                  = form.input :account,
-                    label: t('activerecord.attributes.bank_account.account') do
-                    = text_field_tag 'bank_account[conta]', @bank_account.conta,
-                      class: 'text required w-input text-field', required: true
+                  .u-marginbottom-40
+                    = form.input :agency_digit,
+                      label: t('activerecord.attributes.bank_account.agency_digit') do
+                      = text_field_tag 'bank_account[agencia_dv]',
+                        @bank_account.agencia_dv, maxlength: 2,
+                        class: 'text optional w-input text-field'
 
-                .u-marginbottom-40
-                  = form.input :account_digit,
-                    label: t('activerecord.attributes.bank_account.account_digit') do
-                    = text_field_tag 'bank_account[conta_dv]',
-                      @bank_account.conta_dv, required: true, maxlength: 2,
-                      class: 'text required w-input text-field'
+                  .u-marginbottom-40
+                    = form.input :account,
+                      label: t('activerecord.attributes.bank_account.account') do
+                      = text_field_tag 'bank_account[conta]', @bank_account.conta,
+                        class: 'text required w-input text-field', required: true
 
-                .u-marginbottom-40
-                  = form.input :owner_name,
-                    label: t('activerecord.attributes.bank_account.owner_name') do
-                    = text_field_tag 'bank_account[legal_name]',
-                      @bank_account.legal_name || current_user.name,
-                      required: true, class: 'text required w-input text-field'
+                  .u-marginbottom-40
+                    = form.input :account_digit,
+                      label: t('activerecord.attributes.bank_account.account_digit') do
+                      = text_field_tag 'bank_account[conta_dv]',
+                        @bank_account.conta_dv, required: true, maxlength: 2,
+                        class: 'text required w-input text-field'
 
-                .u-marginbottom-40
-                  = form.input :owner_document,
-                    label: t('activerecord.attributes.bank_account.owner_document') do
-                    = text_field_tag 'bank_account[document_number]',
-                      @bank_account.document_number || current_user.cpf,
-                      disabled: (@bank_account.id),
-                      class: 'text required w-input text-field'
-                    = hidden_field_tag 'bank_account[document_number]',
-                      @bank_account.document_number if @bank_account.id
+                  .u-marginbottom-40
+                    = form.input :owner_name,
+                      label: t('activerecord.attributes.bank_account.owner_name') do
+                      = text_field_tag 'bank_account[legal_name]',
+                        @bank_account.legal_name || current_user.name,
+                        maxlength: 30, minlength: 5, required: true,
+                        class: 'text required w-input text-field'
+
+                  .u-marginbottom-40
+                    = form.input :owner_document,
+                      label: t('activerecord.attributes.bank_account.owner_document') do
+                      = text_field_tag 'bank_account[document_number]',
+                        @bank_account.document_number || current_user.cpf,
+                        disabled: (@bank_account.id),
+                        class: 'text required w-input text-field'
+                      = hidden_field_tag 'bank_account[document_number]',
+                        @bank_account.document_number if @bank_account.id
 
         .w-col.w-col-4
           .w-hidden-main.w-hidden-medium.card.u-radius.card-notification.zindex-20

--- a/app/workers/recipient_worker.rb
+++ b/app/workers/recipient_worker.rb
@@ -1,0 +1,9 @@
+class RecipientWorker
+  include Sidekiq::Worker
+
+  def perform (project_id, account_info)
+    Project.find(project_id).update_attributes(recipient_job_running: true)
+
+    PagarmeService.process(project_id, account_info)
+  end
+end

--- a/config/locales/catarse_bootstrap/views/projects/show.pt.yml
+++ b/config/locales/catarse_bootstrap/views/projects/show.pt.yml
@@ -45,6 +45,8 @@ pt:
       online_days_label: 'Em média os projetos ficam no ar por 40 dias. O prazo máximo da campanha é de 60 dias.'
       value: 'Valor a ser arrecadado'
       value_secondary: 'Grande parte dos apoios serão de pessoas próximas a você. Pense como conseguir pelo menos 50% do valor da meta dentro da sua rede de contatos.'
+      bank_account_job_running_title: 'Atenção:'
+      bank_account_job_running: 'Seus dados bancários estão sendo processados, aguarde.'
       form:
         submit: 'Salvar'
     metrics:

--- a/db/migrate/20160301184237_add_recipient_job_running_to_projects.rb
+++ b/db/migrate/20160301184237_add_recipient_job_running_to_projects.rb
@@ -1,0 +1,5 @@
+class AddRecipientJobRunningToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :recipient_job_running, :boolean, default: false
+  end
+end

--- a/spec/services/pagarme_service_spec.rb
+++ b/spec/services/pagarme_service_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe PagarmeService do
   describe '.process' do
-    let(:project) { build :project }
     let(:recipient_id) { 're_ciknzf3jp003eyn6erpmwarkk' }
     let(:recipient_response) {{ "id" => recipient_id }}
     let(:account_info) {{
@@ -14,9 +13,11 @@ RSpec.describe PagarmeService do
       legal_name: 'Juntos com você API'
     }}
 
-    subject { described_class.process(project, account_info) }
+    subject { described_class.process(project.id, account_info) }
 
     context 'when creating a new recipient' do
+      let(:project) { create :project }
+
       before do
         allow(PagarmeService)
           .to receive(:create_recipient).and_return(recipient_response)
@@ -27,14 +28,14 @@ RSpec.describe PagarmeService do
         subject
       end
 
-      it 'updates the recipient attribute on the project' do
+      it 'updates the recipient attribute on project' do
         expect { subject }
-          .to change { project.recipient }.from(nil).to(recipient_id)
+          .to change { project.reload.recipient }.from(nil).to(recipient_id)
       end
     end
 
     context 'when updating recipient information' do
-      let(:project) { build :project, recipient: recipient_id }
+      let(:project) { create :project, recipient: recipient_id }
 
       before do
         allow(PagarmeService).to receive(:update_recipient_bank_account)

--- a/spec/workers/recipient_worker_spec.rb
+++ b/spec/workers/recipient_worker_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+require 'sidekiq/testing'
+Sidekiq::Testing.fake!
+
+RSpec.describe RecipientWorker do
+  describe '.perform_async' do
+    let(:project) { create :project }
+    let(:account_info) do
+      {
+        "bank_code" => '001',
+        "agencia" => '0001',
+        "conta" => '000001',
+        "conta_dv" => '00',
+        "document_number" => '111.111.111-11',
+        "legal_name" => 'Juntos com você API'
+      }
+    end
+
+    subject { described_class.perform_async(project.id, account_info) }
+
+    it 'enqueues a job' do
+      expect {subject}.to change(described_class.jobs, :size).by(1)
+    end
+
+    it 'calls PagarmeService' do
+      Sidekiq::Testing.inline! do
+        expect(PagarmeService)
+          .to receive(:process).with(project.id, account_info)
+
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
To prevent users from sending multiple requests to insert their bank account information, we have to disable those fields and show them a message.