### PR TITLE
Process images on background to avoid timeouts

### DIFF
--- a/app/assets/javascripts/app/project/project_image_uploader.js
+++ b/app/assets/javascripts/app/project/project_image_uploader.js
@@ -42,7 +42,7 @@ App.ProjectImageUploader = {
 
   removeImage: function (e) {
     e.preventDefault();
-    e.currentTarget.closest('[data-thumbnail-card]').remove();
+    $(e.currentTarget).closest('[data-thumbnail-card]').remove();
     this.disableFileInput(!this.onLimit());
   }
 }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -36,7 +36,7 @@ class Project < ActiveRecord::Base
   has_many :subgoals, -> { order 'value DESC' }
 
   accepts_nested_attributes_for :project_images,
-    limit: CatarseSettings[:project_images_limit],
+    limit: CatarseSettings[:project_images_limit].to_i,
     allow_destroy: true,
     reject_if: :reject_project_image
 
@@ -312,7 +312,7 @@ class Project < ActiveRecord::Base
   end
 
   def project_images_limit?
-    project_images.count == CatarseSettings[:project_images_limit]
+    project_images.count == CatarseSettings[:project_images_limit].to_i
   end
 
   private

--- a/app/models/project_image.rb
+++ b/app/models/project_image.rb
@@ -2,13 +2,20 @@ class ProjectImage < ActiveRecord::Base
   belongs_to :project
   mount_uploader :image, ProjectUploader
 
-  validates :original_image_url, presence: true
+  validates_presence_of :original_image_url, on: :create
 
   before_save :check_url
+  after_commit :process_async, on: :create
 
   private
 
   def check_url
-    self.image_processing = (new_record? || original_image_url?)
+    self.image_processing = true if new_record? && original_image_url
+  end
+
+  def process_async
+    if original_image_url && image_processing
+      ProjectImageProcessWorker.perform_async(self.id, original_image_url)
+    end
   end
 end

--- a/app/views/juntos_bootstrap/projects/image_thumbs/_gallery_thumb.html.slim
+++ b/app/views/juntos_bootstrap/projects/image_thumbs/_gallery_thumb.html.slim
@@ -3,7 +3,7 @@
     - if project_image.image_processing?
       = image_tag 'image_processing.gif', class: 'thumbnail u-marginbottom-10'
     - else
-      = image_tag project_image.image.url, 
+      = image_tag project_image.image.project_thumb.url,
         class: 'thumbnail u-marginbottom-10'
 
     label.field-label Legenda da imagem
@@ -14,8 +14,7 @@
     = hidden_field_tag 'project[project_images_attributes][][id]',
       project_image.id
 
-    = hidden_field_tag 'project[project_images_attributes][][original_image_url]',
-      project_image.original_image_url
+    = hidden_field_tag 'project[project_images_attributes][][original_image_url]', nil
 
     = hidden_field_tag 'project[project_images_attributes][][_destroy]', false,
       data: { destroy_image: true }

--- a/app/views/juntos_bootstrap/projects/templates/_thumbnail_card_template.html.slim
+++ b/app/views/juntos_bootstrap/projects/templates/_thumbnail_card_template.html.slim
@@ -1,6 +1,7 @@
 script type='text/template' data-thumbnail-card-template='true'
   | <div class="w-col w-col-5 w-sub-col u-marginbottom-30 u-marginleft-20
-  |   u-marginright-20 card card-secondary thumbnail-card">
+  |   u-marginright-20 card card-secondary thumbnail-card"
+  |   data-thumbnail-card="true">
   |   <div class="u-marginleft-20">
   |     <img class="thumbnail u-marginbottom-10" src="{{= url }}">
   |     

--- a/app/workers/project_image_process_worker.rb
+++ b/app/workers/project_image_process_worker.rb
@@ -1,0 +1,13 @@
+class ProjectImageProcessWorker
+  include Sidekiq::Worker
+
+  def perform(image_id, url)
+    image = ProjectImage.find(image_id)
+
+    image.update_attributes({
+      original_image_url: nil,
+      remote_image_url: url,
+      image_processing: false
+    })
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -175,4 +175,10 @@ FactoryGirl.define do
     f.association :user, factory: :user
     value 100
   end
+
+  factory :project_image do |f|
+    f.association :project, factory: :project
+    f.caption 'Image caption'
+    f.original_image_url 'http://juntos.com.vc/assets/juntos/logo-small.png'
+  end
 end

--- a/spec/models/project_image_spec.rb
+++ b/spec/models/project_image_spec.rb
@@ -2,5 +2,5 @@ require 'rails_helper'
 
 RSpec.describe ProjectImage, type: :model do
   it { is_expected.to belong_to :project }
-  it { is_expected.to validate_presence_of :original_image_url }
+  it { is_expected.to validate_presence_of(:original_image_url).on(:create) }
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,5 +1,7 @@
 # coding: utf-8
 require 'rails_helper'
+require 'sidekiq/testing'
+Sidekiq::Testing.fake!
 
 RSpec.describe Project, type: :model do
   let(:project){ build(:project, goal: 3000) }
@@ -688,6 +690,28 @@ RSpec.describe Project, type: :model do
       it 'returns the category color' do
         expect(subject).to eq category.color
       end
+    end
+  end
+
+  describe '#project_images_limit?' do
+    let(:project) { create :project }
+
+    subject { project.reload.project_images_limit? }
+
+    context 'when project has no images' do
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when project has less than eight images' do
+      let!(:project_images) { create_list :project_image, 5, project: project }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when project has reached the images limit' do
+      let!(:project_images) { create_list :project_image, 8, project: project }
+
+      it { is_expected.to be_truthy }
     end
   end
 

--- a/spec/workers/project_image_process_worker_spec.rb
+++ b/spec/workers/project_image_process_worker_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+require 'sidekiq/testing'
+Sidekiq::Testing.fake!
+
+RSpec.describe ProjectImageProcessWorker do
+  describe '.perform_async' do
+    let!(:project_image) { create :project_image }
+
+    subject do
+      described_class.perform_async(project_image.id,
+                                    project_image.original_image_url)
+    end
+
+    it 'enqueues a job' do
+      expect { subject }.to change(described_class.jobs, :size).by(1)
+    end
+
+    it 'updates the image resource' do
+      Sidekiq::Testing.inline! do
+        expect { subject }.to change { project_image.reload.image? }
+          .from(false).to(true)
+      end
+    end
+
+    it 'sets the original url to nil' do
+      Sidekiq::Testing.inline! do
+        expect { subject }.to change { project_image.reload.original_image_url }
+          .from(project_image.original_image_url).to(nil)
+      end
+    end
+
+    it 'sets the image processing field to false' do
+      Sidekiq::Testing.inline! do
+        expect { subject }.to change { project_image.reload.image_processing? }
+          .from(true).to(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Images images will now be processed by CarrierWave via a Sidekiq worker
in order to avoid timeouts on Heroku; While the image is being processed a
loading gif placeholder will take its place.