### PR TITLE
Fix ProjectUploaderSpec

### DIFF
--- a/spec/uploaders/project_uploader_spec.rb
+++ b/spec/uploaders/project_uploader_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ProjectUploader do
 
   describe '#project_thumb' do
     subject{ @uploader.project_thumb }
-    it{ is_expected.to have_dimensions(220, 172) }
+    it{ is_expected.to have_dimensions(220, 120) }
   end
 
   describe '#project_thumb' do


### PR DESCRIPTION
The size of project thumbnail was changed on [this commit](https://github.com/juntos-com-vc/juntos.com.vc/commit/db90a66a3f1aa8cffa87008b04ad79c9bb71a1a3) but the spec wasn't updated :disappointed:.