### PR TITLE
Create a task to migrate users documents urls

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,10 @@ class User < ActiveRecord::Base
     :cpf, :state_inscription, :locale, :twitter, :facebook_link, :other_link, :moip_login, :deactivated_at, :reactivate_token,
     :bank_account_attributes, :access_type, :responsible_name, :responsible_cpf, :mobile_phone, :gender,
     :doc1, :doc2, :doc3, :doc4, :doc5, :doc6, :doc7, :doc8, :doc9, :doc10, :doc11, :doc12, :doc13, :staff,
-    :job_title, :birth_date, :admin
+    :job_title, :birth_date, :admin, :original_doc1_url, :original_doc2_url,
+    :original_doc3_url, :original_doc4_url, :original_doc5_url, :original_doc6_url,
+    :original_doc7_url, :original_doc8_url, :original_doc9_url, :original_doc10_url,
+    :original_doc11_url, :original_doc12_url, :original_doc13_url
 
   enum access_type: [:individual, :legal_entity]
   enum staff: [:team, :financial_board, :technical_board, :advice_board]

--- a/app/services/user/fix_users_documents_url_service.rb
+++ b/app/services/user/fix_users_documents_url_service.rb
@@ -1,0 +1,21 @@
+class User::FixUsersDocumentsURLService
+  def self.process
+    User.find_each do |user|
+      user.update_attributes({
+        original_doc1_url: user.doc1.url,
+        original_doc2_url: user.doc2.url,
+        original_doc3_url: user.doc3.url,
+        original_doc4_url: user.doc4.url,
+        original_doc5_url: user.doc5.url,
+        original_doc6_url: user.doc6.url,
+        original_doc7_url: user.doc7.url,
+        original_doc8_url: user.doc8.url,
+        original_doc9_url: user.doc9.url,
+        original_doc10_url: user.doc10.url,
+        original_doc11_url: user.doc11.url,
+        original_doc12_url: user.doc12.url,
+        original_doc13_url: user.doc13.url
+      })
+    end
+  end
+end

--- a/db/migrate/20160406214956_add_original_documents_url_to_users.rb
+++ b/db/migrate/20160406214956_add_original_documents_url_to_users.rb
@@ -1,0 +1,17 @@
+class AddOriginalDocumentsUrlToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :original_doc1_url, :string
+    add_column :users, :original_doc2_url, :string
+    add_column :users, :original_doc3_url, :string
+    add_column :users, :original_doc4_url, :string
+    add_column :users, :original_doc5_url, :string
+    add_column :users, :original_doc6_url, :string
+    add_column :users, :original_doc7_url, :string
+    add_column :users, :original_doc8_url, :string
+    add_column :users, :original_doc9_url, :string
+    add_column :users, :original_doc10_url, :string
+    add_column :users, :original_doc11_url, :string
+    add_column :users, :original_doc12_url, :string
+    add_column :users, :original_doc13_url, :string
+  end
+end

--- a/lib/tasks/fix_user_documents_url.rake
+++ b/lib/tasks/fix_user_documents_url.rake
@@ -1,0 +1,7 @@
+namespace :users do
+  desc 'Fix users documents urls'
+  task 'fix_user_documents_url' => :environment do
+    puts "--- Fixing users documents url in order to remove uploader"
+    User::FixUsersDocumentsURLService.process
+  end
+end

--- a/spec/services/user/fix_users_documents_url_service_spec.rb
+++ b/spec/services/user/fix_users_documents_url_service_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe User::FixUsersDocumentsURLService do
+  describe '.process' do
+    let(:fake_document) { 'http://juntos.com.vc/assets/juntos/logo-small.png' }
+    let!(:user) { create :user }
+
+    subject { described_class.process }
+
+    before do
+      allow_any_instance_of(DocumentUploader)
+        .to receive(:url).and_return(fake_document)
+    end
+
+    it "updates the resource" do
+      expect { subject }.to change { user.reload.original_doc1_url }
+          .from(nil).to(fake_document)
+    end
+  end
+end

--- a/spec/tasks/fix_user_documents_url_rake_spec.rb
+++ b/spec/tasks/fix_user_documents_url_rake_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'Users' do
+  before(:all) do
+    Rake.application.rake_require "tasks/fix_user_documents_url"
+    Rake::Task.define_task(:environment)
+  end
+
+  describe 'fix_user_documents_url' do
+    let(:run_rake_task) do
+      Rake::Task['users:fix_user_documents_url'].reenable
+      Rake.application.invoke_task 'users:fix_user_documents_url'
+    end
+
+    let(:service) { double('fix order user service') }
+
+    it { expect {run_rake_task}.to output(/Fixing users documents/).to_stdout } 
+  end
+end


### PR DESCRIPTION
As we're changing the way user documents are uploaded on the platform
we need to migrate the existing data to a new field wich will stote this data
from now