### PR TITLE
Fix typo on S3 Direct Upload configuration

### DIFF
--- a/config/initializers/s3_direct_upload.rb
+++ b/config/initializers/s3_direct_upload.rb
@@ -1,7 +1,7 @@
 S3DirectUpload.config do |c|
   c.access_key_id = ENV['AWS_ACCESS_KEY']
   c.secret_access_key = ENV['AWS_SECRET_KEY']
-  c.bucket = ENV['AWS_BUCKET'],
+  c.bucket = ENV['AWS_BUCKET']
   c.region = 'sa-east-1'
-  c.url = "https://#{ENV['AWS_BUCKET']}.s3.amazonaws.com"
+  c.url = "https://#{c.bucket}.s3.amazonaws.com"
 end


### PR DESCRIPTION
An unecessary comma caused an Invalid Policy error while trying to
upload files do Amazon S3.