### PR TITLE
Show original uploaded images on project dashboard

### DIFF
--- a/app/views/juntos_bootstrap/projects/image_thumbs/_gallery_thumb.html.slim
+++ b/app/views/juntos_bootstrap/projects/image_thumbs/_gallery_thumb.html.slim
@@ -1,7 +1,8 @@
 .w-col.w-col-5.w-sub-col.u-marginbottom-30.u-marginleft-20.u-marginright-20.card.card-secondary.thumbnail-card[data-thumbnail-card="true"]
   .u-marginleft-20
     - if project_image.image_processing?
-      = image_tag 'image_processing.gif', class: 'thumbnail u-marginbottom-10'
+      = image_tag project_image.original_image_url,
+        class: 'thumbnail u-marginbottom-10'
     - else
       = image_tag project_image.image.project_thumb.url,
         class: 'thumbnail u-marginbottom-10'

--- a/app/views/juntos_bootstrap/projects/image_thumbs/_partner_thumb.html.slim
+++ b/app/views/juntos_bootstrap/projects/image_thumbs/_partner_thumb.html.slim
@@ -1,7 +1,8 @@
 .w-col.w-col-5.w-sub-col.u-marginbottom-30.u-marginleft-20.u-marginright-20.card.card-secondary.thumbnail-card[data-thumbnail-card="true"]
   .u-marginleft-20
     - if project_partner.image_processing?
-      = image_tag 'image_processing.gif', class: 'thumbnail u-marginbottom-10'
+      = image_tag project_partner.original_image_url,
+        class: 'thumbnail u-marginbottom-10'
     - else
       = image_tag project_partner.image.thumb.url,
         class: 'thumbnail u-marginbottom-10'


### PR DESCRIPTION
Display non-processed (resized) images on project dashboard after saving
changes. Before, it was showing a loading GIF.