### PR TITLE
Keep the upload progress bar on page

### DIFF
--- a/app/assets/javascripts/app/project/project_cover_uploader.js
+++ b/app/assets/javascripts/app/project/project_cover_uploader.js
@@ -8,7 +8,9 @@ App.ProjectCoverUploader = {
   },
 
   activate: function () {
-    this.$el.find('[data-s3-uploader]').S3Uploader();
+    this.$el.find('[data-s3-uploader]').S3Uploader({
+      remove_completed_progress_bar: false
+    });
   },
 
   uploadComplete: function (e, content) {


### PR DESCRIPTION
On project dashboard, in the cover images section, we should keep the progress bar on page after the upload has been completed.