### PR TITLE
Allow channels to customize submit project message

### DIFF
--- a/app/decorators/channel_decorator.rb
+++ b/app/decorators/channel_decorator.rb
@@ -13,6 +13,14 @@ class ChannelDecorator < Draper::Decorator
     source.website.gsub(/https?:\/\//i, '')
   end
 
+  def submit_your_project_text
+    if source.custom_submit_text.blank?
+      I18n.t(:submit_your_project, scope: [:layouts, :header])
+    else
+      source.custom_submit_text
+    end
+  end
+
   private
   def last_fragment(uri)
     uri.split("/").last

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -24,7 +24,9 @@ class Channel < ActiveRecord::Base
   catarse_auto_html_for field: :contacts, video_width: 560, video_height: 340
   catarse_auto_html_for field: :description, video_width: 560, video_height: 340
 
-  delegate :display_facebook, :display_twitter, :display_website, to: :decorator
+  delegate :display_facebook, :display_twitter, :display_website,
+           :submit_your_project_text, to: :decorator
+
   mount_uploader :image, ProfileUploader
 
   scope :by_permalink, ->(p) { where("lower(channels.permalink) = lower(?)", p) }

--- a/app/views/juntos_bootstrap/admin/channels/_form.html.slim
+++ b/app/views/juntos_bootstrap/admin/channels/_form.html.slim
@@ -20,6 +20,9 @@
       = form.input :recurring, as: :select, collection: [:true, :false],
         prompt: false, required: true
   .w-row
+    .w-col.w-col-6
+      = form.input :custom_submit_text, as: :string
+  .w-row
     .w-col.w-col-12
       = form.input :description, as: :text, required: true
 

--- a/app/views/juntos_bootstrap/shared/_header_channel.html.slim
+++ b/app/views/juntos_bootstrap/shared/_header_channel.html.slim
@@ -1,5 +1,9 @@
 - content_for :header_controls do
-  = link_to "Envie seu projeto", channels_about_path, class: 'header-link w-nav-link'
-  = link_to "Termos de uso", channels_terms_path, class: 'header-link w-nav-link'
-  = link_to "Contatos", channels_contacts_path, class: 'header-link w-nav-link'
+  = link_to resource.submit_your_project_text,
+    channels_about_path, class: 'header-link w-nav-link'
+  = link_to t(:terms_of_use, scope: [:layouts, :header]),
+      channels_terms_path, class: 'header-link w-nav-link'
+  = link_to t(:contacts, scope: [:layouts, :header]),
+    channels_contacts_path, class: 'header-link w-nav-link'
+
 = render 'shared/header'

--- a/config/locales/catarse_bootstrap/activerecord.pt.yml
+++ b/config/locales/catarse_bootstrap/activerecord.pt.yml
@@ -131,6 +131,8 @@ pt:
         privacy: Política de privacidade
         contacts: Contatos
         recurring: Recorrente
+        category_id: Categoria
+        custom_submit_text: Texto de envio personalizado
       channel_partner:
         name: 'Nome'
         url: 'Site'

--- a/config/locales/catarse_bootstrap/views/layouts/header.pt.yml
+++ b/config/locales/catarse_bootstrap/views/layouts/header.pt.yml
@@ -13,6 +13,9 @@ pt:
       search: Busque projetos
       how_it_works: Como funciona
       about: A juntos
+      submit_your_project: Envie seu projeto
+      terms_of_use: Termos de uso
+      contacts: Contatos
     login:
       login_with_facebook: entre com sua conta do facebook
     user:

--- a/db/migrate/20160412163357_add_custom_submit_text_to_channels.rb
+++ b/db/migrate/20160412163357_add_custom_submit_text_to_channels.rb
@@ -1,0 +1,5 @@
+class AddCustomSubmitTextToChannels < ActiveRecord::Migration
+  def change
+    add_column :channels, :custom_submit_text, :string
+  end
+end

--- a/spec/decorators/channel_decorator_spec.rb
+++ b/spec/decorators/channel_decorator_spec.rb
@@ -17,5 +17,22 @@ RSpec.describe ChannelDecorator do
     subject{ channel.display_website }
     it{ is_expected.to eq('foobar.com') }
   end
+
+  describe '#submit_your_project_text' do
+    subject { channel.submit_your_project_text }
+
+    context 'when channel has a custom submit project text' do
+      let(:channel) { build :channel, custom_submit_text: 'Custom text' }
+
+      it { is_expected.to eq channel.custom_submit_text }
+    end
+
+    context 'when does not have a custom submit project text' do
+      it 'returns the default text' do
+        is_expected
+          .to eq I18n.t(:submit_your_project, scope: [:layouts, :header])
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
By adding a new field to the database, we're allowing project admins
to modify the "Submit your project" message