### PR TITLE
[Fix] Custom submit text on channels

### DIFF
--- a/app/views/juntos_bootstrap/shared/_header_channel.html.slim
+++ b/app/views/juntos_bootstrap/shared/_header_channel.html.slim
@@ -1,5 +1,5 @@
 - content_for :header_controls do
-  = link_to resource.submit_your_project_text,
+  = link_to channel.submit_your_project_text,
     channels_about_path, class: 'header-link w-nav-link'
   = link_to t(:terms_of_use, scope: [:layouts, :header]),
       channels_terms_path, class: 'header-link w-nav-link'


### PR DESCRIPTION
Using `resource` causes an error while rendering a project page (`resource` in this context is the project itself, not the channel).