### PR TITLE
Update email_image method on channel decorator

### DIFF
--- a/app/decorators/channel_decorator.rb
+++ b/app/decorators/channel_decorator.rb
@@ -22,7 +22,11 @@ class ChannelDecorator < Draper::Decorator
   end
 
   def email_image
-    source.email_header_image.blank? ?  source.image : source.email_header_image
+    if source.email_header_image.blank?
+      source.image.url
+    else
+      source.email_header_image.url
+    end
   end
 
   private

--- a/spec/decorators/channel_decorator_spec.rb
+++ b/spec/decorators/channel_decorator_spec.rb
@@ -36,13 +36,17 @@ RSpec.describe ChannelDecorator do
   end
 
   describe '#email_image' do
-    let(:fake_image) { 'http://juntos.com.vc/assets/juntos/logo.png' }
-    let(:fake_email_image) { 'http://juntos.com.vc/assets/juntos/logo-small.png' }
+    let(:fake_image) { instance_double('ProfileUploader') }
+    let(:fake_email_image) { instance_double('ProfileUploader') }
 
     subject { channel.email_image }
 
     before do
-      allow(channel).to receive_messages(image: fake_image)
+      allow(fake_image).to receive(:url)
+        .and_return('http://juntos.com.vc/assets/juntos/logo.png')
+
+      allow(fake_email_image).to receive(:url)
+        .and_return('http://juntos.com.vc/assets/juntos/logo-small.png')
     end
 
     context 'when channel has a custom email header image' do
@@ -52,7 +56,7 @@ RSpec.describe ChannelDecorator do
         allow(channel).to receive_messages(email_header_image: fake_email_image)
       end
 
-      it { is_expected.to eq channel.email_header_image }
+      it { is_expected.to eq channel.email_header_image.url }
     end
 
     context 'when channel does not have a custom email header image' do
@@ -60,7 +64,7 @@ RSpec.describe ChannelDecorator do
 
       before { allow(channel).to receive_messages(image: fake_image) }
 
-      it { is_expected.to eq channel.image }
+      it { is_expected.to eq channel.image.url }
     end
   end
 end


### PR DESCRIPTION
As the images will be used on e-mails we must pass an absolute url.