### PR TITLE
Redirect unauthorized users when trying to download reports

### DIFF
--- a/app/controllers/reports/contribution_reports_for_project_owners_controller.rb
+++ b/app/controllers/reports/contribution_reports_for_project_owners_controller.rb
@@ -1,8 +1,12 @@
 class Reports::ContributionReportsForProjectOwnersController < Reports::BaseController
   def index
-    @report = end_of_association_chain.to_xls( columns: I18n.t('contribution_report_to_project_owner').values )
-    super do |format|
-      format.xls { send_data @report, filename: 'apoiadores.xls' }
+    if policy(Project.find(params[:project_id])).update?
+      @report = end_of_association_chain.to_xls( columns: I18n.t('contribution_report_to_project_owner').values )
+      super do |format|
+        format.xls { send_data @report, filename: 'apoiadores.xls' }
+      end
+    else
+      redirect_to root_path
     end
   end
 

--- a/spec/controllers/reports/contribution_reports_for_project_owners_controller_spec.rb
+++ b/spec/controllers/reports/contribution_reports_for_project_owners_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Reports::ContributionReportsForProjectOwnersController, type: :controller do
+  include Devise::TestHelpers
+
+  describe '#index' do
+    let(:project) { create :project }
+
+    subject { response }
+
+    context 'when the current user has admin access to the project' do
+      before { sign_in project.user }
+
+      it 'allows the user to download the report' do
+        get :index, project_id: project.id, locale: :pt, format: :csv
+
+        expect(subject).to be_success
+      end
+    end
+
+    context 'unauthorized access' do
+      before { get :index, project_id: project.id, locale: :pt, format: :csv }
+
+      context 'when the current user does not have admin access to the project' do
+        let(:unauthorized) { build :user }
+
+        before { sign_in unauthorized }
+
+        it { is_expected.to redirect_to root_path }
+      end
+
+      context 'when there is no user logged in' do
+        it { is_expected.to redirect_to root_path }
+      end
+    end
+  end
+end


### PR DESCRIPTION
When an unauthorized user tries to download a contributions report, the application was just displaying an HTTP 500 error. Now they'll get redirected to the homepage.