### PR TITLE
Fix error 500 when sending XHR for project searching

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -142,7 +142,7 @@ class Project < ActiveRecord::Base
 
   scope :recurring, -> { joins(:channels).merge(Channel.recurring(true)) }
 
-  scope :without_recurring, -> { where('id NOT IN (?)', recurring.map(&:id)) unless recurring.empty? }
+  scope :without_recurring, -> { where('projects.id NOT IN (?)', recurring.map(&:id)) unless recurring.empty? }
 
   attr_accessor :accepted_terms, :new_record
 


### PR DESCRIPTION
Esse PR corrige o erro 500 arremessado na rota "/pt/projects?pg_search=quilombo&page=1" que impedia a barra de busca por projeto de funcionar.