### PR TITLE
Fix company_name and redirection to catarse

### DIFF
--- a/app/views/juntos_bootstrap/devise/registrations/new.html.slim
+++ b/app/views/juntos_bootstrap/devise/registrations/new.html.slim
@@ -40,4 +40,4 @@ section.devise-body-section
               label.w-form-label.fontsize-smallest= t('.form.labels.newsletter')
             = form.button :submit, t('.form.inputs.submit'), class:'btn btn-medium'
         .fontsize-smallest.u-text-center.u-marginbottom-30
-          = t(".form.labels.accept", terms_url: CatarseSettings[:terms_url]).html_safe
+          = t(".form.labels.accept_html", terms_url: terms_of_use_path)

--- a/app/views/juntos_bootstrap/user_notifier/mailer/contribution_canceled_after_confirmed.html.slim
+++ b/app/views/juntos_bootstrap/user_notifier/mailer/contribution_canceled_after_confirmed.html.slim
@@ -10,5 +10,5 @@ br/
 br/
 |Esse apoio recebeu uma notificação de cancelamento após já ter recebido uma notificação de confirmação.
 br/
-|Verifique no site do meio de pagamento o real status da transação e, se o apoio constar como confirmado, confirme-o no site da #{company_name} (adm/contributions)
 
+|Verifique no site do meio de pagamento o real status da transação e, se o apoio constar como confirmado, confirme-o no site da Juntos.com.vc (adm/contributions)

--- a/app/views/juntos_bootstrap/user_notifier/mailer/in_analysis_project_channel.html.slim
+++ b/app/views/juntos_bootstrap/user_notifier/mailer/in_analysis_project_channel.html.slim
@@ -11,7 +11,7 @@
 |Olá, #{user.name}!
 br
 br
-| Nossa equipe do #{channel.name} acabou de receber o projeto #{link_to project.name, project_link, target: '__blank'}
+| Nossa equipe da #{channel.name} acabou de receber o projeto #{link_to project.name, project_link, target: '__blank'}
 br/
 br/
 | Durante os próximos 4 dias úteis, iremos analisar o rascunho de projeto que você nos enviou e te daremos uma resposta.
@@ -22,7 +22,7 @@ br/
 br/
 strong Opção 1:
 | Seu rascunho passou na análise, foi aceito e poderá ir ao ar!
-| Agora é só marcarmos o dia e hora para estreiar seu projeto no #{channel.name}, no site do #{company_name}!
+| Agora é só marcarmos o dia e hora para estreiar seu projeto no #{channel.name}, no site da #{company_name}!
 br/
 br/
 strong Opção 2:
@@ -31,7 +31,7 @@ strong Opção 2:
 br/
 br/
 strong Opção 3:
-| Infelizmente, o rascunho de projeto que você enviou não se encaixa no perfil do #{channel.name}.
+| Infelizmente, o rascunho de projeto que você enviou não se encaixa no perfil da #{channel.name}.
 | Enviaremos um email notificando a recusa. Sim, sabemos que recusas são sempre desagradáveis. Mas o lema aqui
 | é "levanta, sacode a poeira e dá a volta por cima". Mas antes de sacudir qualquer poeira, estude
 ' a #{link_to 'Central de Suporte', CatarseSettings[:support_forum], target: '__blank'} do #{company_name} e a #{ link_to 'proposta', channels_about_url(subdomain: channel.permalink), target: '__blank'}

--- a/config/locales/catarse_bootstrap/views/devise/registrations/new.en.yml
+++ b/config/locales/catarse_bootstrap/views/devise/registrations/new.en.yml
@@ -22,7 +22,7 @@ en:
             name: 'Full name/Corporate name'
             password: 'Password'
             newsletter: 'I want to receive news on my e-mail'
-            accept: 'When you register, you are accepting our <a href="%{terms_url}" class="alt-link fontcolor-alternative" target="_blank">terms of use and privacy</a>'
+            accept_html: 'When you register, you are accepting our <a href="%{terms_url}" class="alt-link fontcolor-alternative" target="_blank">terms of use and privacy</a>'
           hint:
             password_length: 'Must be at least 6 characters.'
           inputs:

--- a/config/locales/catarse_bootstrap/views/devise/registrations/new.pt.yml
+++ b/config/locales/catarse_bootstrap/views/devise/registrations/new.pt.yml
@@ -16,11 +16,10 @@ pt:
             name: 'Nome completo/Razão social'
             password: 'Senha'
             newsletter: 'Quero receber novidades meu email'
-            accept: 'Ao efetuar cadastro, você está aceitando nossos <a href="%{terms_url}" class="alt-link fontcolor-alternative" target="_blank">termos de uso e privacidade</a>'
+            accept_html: 'Ao efetuar cadastro, você está aceitando nossos <a href="%{terms_url}" class="alt-link fontcolor-alternative" target="_blank">termos de uso e privacidade</a>'
             access_type: 'Sou um(a)'
           hint:
             password_length: 'Mínimo de 6 caracteres'
           inputs:
             submit: 'Realizar cadastro'
             facebook: 'Cadastre-se com Facebook'
-


### PR DESCRIPTION
Context: 

- After a user cancel a contribution, he recives an email. In the message the company_name is wrong, display **Cartase** instead **Juntos com vc**.

- On sign_up page form, when a user click on,  **terms of use and privacy** he is redirect to **Cartase** instead **Juntos com vc**.