### PR TITLE
Updates in cancel recurring contribution

### DIFF
--- a/app/controllers/admin/contributions_controller.rb
+++ b/app/controllers/admin/contributions_controller.rb
@@ -8,6 +8,9 @@ class Admin::ContributionsController < Admin::BaseController
   has_scope :platform_contributions, type: :boolean
   has_scope :between_values, using: [ :start_at, :ends_at ], allow_blank: true
   has_scope :partner_indications, type: :boolean
+  has_scope :only_recurring, type: :boolean
+  has_scope :only_cancelled_recurring, type: :boolean
+
   before_filter :set_title
 
   def self.contribution_actions

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -78,6 +78,10 @@ class Contribution < ActiveRecord::Base
   # Contributions already refunded or with requested_refund should appear so that the user can see their status on the refunds list
   scope :can_refund, ->{ where("contributions.can_refund") }
 
+  scope :only_recurring, ->{ where.not(recurring_contribution: nil) }
+  scope :only_cancelled_recurring, -> { only_recurring.includes(:recurring_contribution)
+                                          .where.not(recurring_contributions: { cancelled_at: nil }) }
+
   attr_protected :state
 
   def self.between_values(start_at, ends_at)

--- a/app/views/juntos_bootstrap/admin/contributions/index.html.slim
+++ b/app/views/juntos_bootstrap/admin/contributions/index.html.slim
@@ -42,6 +42,12 @@
           = form.input :platform_contributions, as: :boolean, label: t('.platform_contributions')
         .w-col-2.w-col
           = form.input :partner_indications, as: :boolean, label: t('.partner_indication')
+        .w-col-2.w-col
+          = form.input :only_recurring, as: :boolean, label: t('.only_recurring')
+        .w-col-2.w-col
+          = form.input :only_cancelled_recurring, as: :boolean, label: t('.only_cancelled_recurring')
+      .w-row
+        .w-col-8.w-col
         .w-col.w-col-2.u-margintop-20
           = link_to t('.search_report'), admin_contributions_path(params: params,format: :csv), class: 'btn bt-medium'
         .w-col-2.w-col.u-margintop-20

--- a/app/views/juntos_bootstrap/projects/show.html.slim
+++ b/app/views/juntos_bootstrap/projects/show.html.slim
@@ -210,7 +210,9 @@ nav.project-nav.w-hidden-main.w-hidden-medium
             .fontsize-large.fontweight-light.u-margintop-30
               = t('.contribute_project.already_contributing')
             .fontsize-smallest.fontweight-light.u-marginbottom-30
-              = link_to t('.contribute_project.cancel'), cancel_recurring_project_path(@project)
+              = link_to t('.contribute_project.cancel'), 
+                  cancel_recurring_project_path(@project), 
+                  data: { confirm: t('.contribute_project.confirm') }
         - else
           - if @project.online? && !@project.expired? && @project.id != 629
             - if project_aumigo

--- a/app/views/juntos_bootstrap/user_notifier/mailer/contribution_canceled_after_confirmed.html.slim
+++ b/app/views/juntos_bootstrap/user_notifier/mailer/contribution_canceled_after_confirmed.html.slim
@@ -1,4 +1,6 @@
 - contribution = @notification.contribution
+- company_name = CatarseSettings[:company_name]
+
 |Projeto: #{contribution.project.name}
 br/
 |Chave do apoio: #{contribution.key}
@@ -8,5 +10,5 @@ br/
 br/
 |Esse apoio recebeu uma notificação de cancelamento após já ter recebido uma notificação de confirmação.
 br/
-|Verifique no site do meio de pagamento o real status da transação e, se o apoio constar como confirmado, confirme-o no site do Catarse (adm/contributions)
+|Verifique no site do meio de pagamento o real status da transação e, se o apoio constar como confirmado, confirme-o no site da #{company_name} (adm/contributions)
 

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -163,7 +163,6 @@ en:
           acquirer_name: 'Acquirer name'
           installments: 'Installments'
           created_at: 'Created at'
-
         placeholders:
           project: 'Project name or permalink'
           acquirer: 'Acquirer name'
@@ -213,6 +212,8 @@ en:
         platform_value: 'Amount to the platform'
         project_value: 'Amount to the project'
         partner_indication: 'Partner indication'
+        only_recurring: Only recurring 
+        only_cancelled_recurring: Recurring cancelled 
 
     statistics:
       index:

--- a/config/locales/admin.pt.yml
+++ b/config/locales/admin.pt.yml
@@ -163,7 +163,6 @@ pt:
           acquirer_name: 'Operadora de cartão'
           installments: 'Parcelas'
           created_at: 'Iniciado em'
-
         placeholders:
           project: 'Permalink ou nome do projeto'
           acquirer: 'Nome da operadora de cartão'
@@ -217,6 +216,8 @@ pt:
         partner_indication: Indicação de parceiros
         search_report: Exportar CSV
         emails: Emails
+        only_recurring: Somente recorrentes
+        only_cancelled_recurring: Recorrentes canceladas
 
     statistics:
       index:

--- a/config/locales/catarse_bootstrap/views/projects/show.en.yml
+++ b/config/locales/catarse_bootstrap/views/projects/show.en.yml
@@ -157,6 +157,7 @@ en:
         submit-mobile: 'Support this project'
         donate: 'DONATE'
         cancel: 'Cancel support'
+        confirm: Are you sure that you want cancel your support?
         already_contributing: 'You are already contributing with this project'
         donate: DONATE
       project_by: 'project by'

--- a/config/locales/catarse_bootstrap/views/projects/show.pt.yml
+++ b/config/locales/catarse_bootstrap/views/projects/show.pt.yml
@@ -160,6 +160,7 @@ pt:
         submit: Apoiar este projeto
         submit-mobile: Apoiar este projeto
         cancel: Cancelar apoio
+        confirm: Tem certeza que voce deseja cancelar seu apoio a este projeto?
         already_contributing: Você já apoia este projeto
         donate: DOAR
       project_by: projeto por

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -252,5 +252,37 @@ RSpec.describe Contribution, type: :model do
     end
   end
 
+  describe '.only_recurring' do
+    subject { Contribution.only_recurring }
 
+    context 'when we dont have any recurring contribution' do
+      it { is_expected.to have(0).item }
+    end
+
+    context 'when we have recurring contributions' do
+      before do
+        recurring_contribution = create(:recurring_contribution, contributions: [contribution])
+        contribution.update_attributes(recurring_contribution: recurring_contribution)
+      end
+
+      it { is_expected.to have(1).item }
+    end
+  end
+
+  describe '.only_cancelled_recurring' do
+    subject { Contribution.only_recurring }
+
+    context 'when we dont have any cancelled recurring contribution' do
+      it { is_expected.to have(0).item }
+    end
+
+    context 'when we have cancelled recurring contributions' do
+      before do
+        recurring_contribution = create(:recurring_contribution, contributions: [contribution], cancelled_at: Time.now)
+        contribution.update_attributes(recurring_contribution: recurring_contribution)
+      end
+
+      it { is_expected.to have(1).item }
+    end
+  end
 end


### PR DESCRIPTION
Wrong company name in email that is sent when contribution is cancelled, add a confirm with "are you sure" message when cancelling a recurring contribution and add filters `only recurring contributions` and `only cancel recurring contributions` in contributions admin.