### PR TITLE
Remove pagination when exporting csv file

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -10,7 +10,7 @@ class Admin::UsersController < Admin::BaseController
       format.html { collection }
       format.csv do
         self.response_body = Enumerator.new do |y|
-          collection.copy_to do |line|
+          collection(false).copy_to do |line|
             y << line
           end
         end
@@ -19,8 +19,12 @@ class Admin::UsersController < Admin::BaseController
   end
 
   protected
-  def collection
-    @users ||= apply_scopes(end_of_association_chain).with_user_totals.order_by(params[:order_by] || 'coalesce(user_totals.sum, 0) DESC').includes(:user_total).page(params[:page])
+  def collection(with_pagination = true)
+    if with_pagination
+      @users ||= apply_scopes(end_of_association_chain).with_user_totals.order_by(params[:order_by]).includes(:user_total).page(params[:page])
+    else
+      apply_scopes(end_of_association_chain).with_user_totals.order_by(params[:order_by])
+    end
   end
 end
 

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
+require 'csv'
 
 RSpec.describe Admin::UsersController, type: :controller do
   subject{ response }
   let(:admin) { create(:user, admin: true) }
   let(:current_user){ admin }
+
   before do
     allow(controller).to receive(:current_user).and_return(current_user)
   end
@@ -23,7 +25,41 @@ RSpec.describe Admin::UsersController, type: :controller do
       end
       its(:status){ should == 200 }
     end
+
+    context "pagination" do
+      before do
+        create_list(:user, 50 - User.count)
+      end
+
+      context "responding to html format" do
+        before do
+          get :index, locale: :en
+        end
+
+        it "returns htm as content type" do
+          expect(response.content_type).to eq("text/html")
+        end
+
+        it "returns 25 users per page" do
+          expect(assigns(:users).size).to match(25)
+        end
+      end
+
+      context "responding to csv format" do
+        before do
+          get :index, format: :csv, locale: :en
+        end
+
+        it "returns csv as content type" do
+          expect(response.content_type).to eq("text/csv")
+        end
+
+        it "returns all users plus header" do
+          csv = CSV.parse(response.body)
+
+          expect(csv.size).to match(51)
+        end
+      end
+    end
   end
-
 end
-


### PR DESCRIPTION
It fixes the problem on exporting only 25 records in csv file.