### PR TITLE
Create specs for Contribution#with_cause scope. Fix Contribution#with…

### DIFF
--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -72,7 +72,7 @@ class Contribution < ActiveRecord::Base
   scope :partner_indications, -> { where(partner_indication: true) }
   scope :can_cancel, -> { where("contributions.can_cancel") }
   scope :with_cause, ->(cause_id) {
-    where('contributions.project_id in (?)', Project.select(:id).where(category_id: cause_id))
+    joins(:project).where(projects: { category_id: cause_id })
   }
 
   # Contributions already refunded or with requested_refund should appear so that the user can see their status on the refunds list

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -72,7 +72,7 @@ class Contribution < ActiveRecord::Base
   scope :partner_indications, -> { where(partner_indication: true) }
   scope :can_cancel, -> { where("contributions.can_cancel") }
   scope :with_cause, ->(cause_id) {
-    where('project_id in (?)', Project.select{|p|p.category.id == cause_id.to_i}.map(&:id))
+    where('contributions.project_id in (?)', Project.select(:id).where(category_id: cause_id))
   }
 
   # Contributions already refunded or with requested_refund should appear so that the user can see their status on the refunds list

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -8,7 +8,11 @@ en:
         edit: 'Edit'
     site_partners:
       index:
+        title: "Juntos's Partners"
         menu: 'Partners'
+        new: 'New Partner'
+        edit: 'Edit'
+        remove: 'Remove'
     channels:
       index:
         menu: 'Channels'
@@ -59,6 +63,7 @@ en:
         by_state: 'By state'
         between_expires_at: 'Expires between'
         by_progress: 'By progress %'
+        no_projects: 'No projects were found'
         details:
           name: 'Legal name'
           bank_data: 'Bank account info'
@@ -108,6 +113,8 @@ en:
       confirm: 'Confirm'
     users:
       index:
+        id: 'ID'
+        email: 'E-mail'
         title: 'Donors management'
         menu: 'Users'
         credits: 'Credits'
@@ -132,6 +139,7 @@ en:
         only_organizations: 'NGOs only'
         access_type: 'Access type'
         search_report: 'Export CSV'
+        no_users: 'No users were found'
     contributions:
       messages:
         successful:
@@ -153,6 +161,10 @@ en:
         user_cpf: 'Registered CPF/CNPJ'
         created_at: 'Created at'
       index:
+        user_id: 'User ID'
+        search_report: 'Search report'
+        project_state: 'State'
+        emails: 'Emails'
         details:
           payer_email: 'Payment'
           user_email: 'At Juntos.com.vc'
@@ -212,8 +224,8 @@ en:
         platform_value: 'Amount to the platform'
         project_value: 'Amount to the project'
         partner_indication: 'Partner indication'
-        only_recurring: Only recurring 
-        only_cancelled_recurring: Recurring cancelled 
+        only_recurring: Only recurring
+        only_cancelled_recurring: Recurring cancelled
 
     statistics:
       index:
@@ -237,6 +249,7 @@ en:
         last_year: 'Last year'
     home_banners:
       index:
+        id: 'ID'
         menu: 'Homepage banners'
         edit: 'Edit'
         destroy: 'Delete'

--- a/config/locales/admin.pt.yml
+++ b/config/locales/admin.pt.yml
@@ -59,6 +59,7 @@ pt:
         by_state: 'Por estado'
         between_expires_at: 'Expiram entre'
         by_progress: Por progresso %
+        no_projects: 'Nenhum projeto encontrado'
         details:
           name: 'Razão social'
           bank_data: 'Dados bancarios'
@@ -108,6 +109,8 @@ pt:
       confirm: 'Confirmar'
     users:
       index:
+        id: 'ID'
+        email: 'E-mail'
         title: "Gerenciamento de apoiadores"
         menu: "Usuários"
         credits: "Créditos"
@@ -132,6 +135,7 @@ pt:
         only_organizations: 'Somente ONGs'
         access_type: 'Tipo de Acesso'
         search_report: 'Exportar CSV'
+        no_users: 'Nenhum usuário encontrado'
     contributions:
       messages:
         successful:
@@ -241,6 +245,7 @@ pt:
         last_year: "Ano anterior"
     home_banners:
       index:
+        id: 'ID'
         menu: 'Banners da home'
         edit: 'Editar'
         destroy: 'Apagar'

--- a/config/locales/rails.en.yml
+++ b/config/locales/rails.en.yml
@@ -193,6 +193,7 @@ en:
   time:
     am: am
     formats:
+      simple: "%m/%d/%Y, %H:%M h"
       estimate: "%B/%Y"
       default: ! '%a, %d %b %Y %H:%M:%S %z'
       long: ! '%B %d, %Y %H:%M'
@@ -206,4 +207,3 @@ en:
   activerecord:
     errors:
       <<: *errors
-

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -285,4 +285,30 @@ RSpec.describe Contribution, type: :model do
       it { is_expected.to have(1).item }
     end
   end
+
+  describe '#with_cause' do
+    let(:category_with_project) { create :category }
+    let(:category_without_project) { create :category }
+    let(:project) { create(:project, state: 'online', category: category_with_project) }
+
+    before do
+      3.times {
+        create(:contribution, state: 'confirmed', project: project)
+      }
+    end
+
+    context 'when category does not have a project' do
+      it 'does not find a contributions having the category as a cause' do
+        contributions = Contribution.with_cause(category_without_project.id)
+        expect(contributions).to have(0).items
+      end
+    end
+
+    context 'when category have registered projects' do
+      it 'does find contributions having the category as a cause' do
+        contributions = Contribution.with_cause(category_with_project.id)
+        expect(contributions).to have(3).items
+      end
+    end
+  end
 end

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -287,27 +287,35 @@ RSpec.describe Contribution, type: :model do
   end
 
   describe '#with_cause' do
-    let(:category_with_project) { create :category }
-    let(:category_without_project) { create :category }
-    let(:project) { create(:project, state: 'online', category: category_with_project) }
+    let(:category) { create(:category) }
+    let(:project) { create(:project) }
 
     before do
-      3.times {
-        create(:contribution, state: 'confirmed', project: project)
-      }
+      create(:contribution, project: project, payer_email: 'test1@test.com')
+      create(:contribution, project: project, payer_email: 'test2@test.com')
+      create(:contribution, project: project, payer_email: 'test3@test.com')
+      create(:contribution, payer_email: 'test4@test.com')
     end
 
     context 'when category does not have a project' do
       it 'does not find a contributions having the category as a cause' do
-        contributions = Contribution.with_cause(category_without_project.id)
+        contributions = Contribution.with_cause(category.id)
         expect(contributions).to have(0).items
       end
     end
 
     context 'when category have registered projects' do
+      before do
+        @contributions = Contribution.with_cause(project.category_id)
+        @payer_emails = @contributions.map(&:payer_email)
+      end
+
       it 'does find contributions having the category as a cause' do
-        contributions = Contribution.with_cause(category_with_project.id)
-        expect(contributions).to have(3).items
+        expect(@payer_emails).to match_array(['test1@test.com', 'test2@test.com', 'test3@test.com'])
+      end
+
+      it 'ommits contributions without the category as a cause' do
+        expect(@payer_emails).not_to include('test4@test.com')
       end
     end
   end


### PR DESCRIPTION
Queries using state filter were breaking only when associated with cause filter. The with_cause scope was not optimized and breaking because some projects doesn't have a category, so the "id" can't be associated with a nil value.

Setting the project_id column reference in the with_cause scope to prevent ambiguous columns error.