### PR TITLE
Move a project to channel

### DIFF
--- a/app/assets/stylesheets/juntos_bootstrap/_main.scss
+++ b/app/assets/stylesheets/juntos_bootstrap/_main.scss
@@ -4163,3 +4163,12 @@ p .project-basics-icons{
 .thumb-contribution-mobile{
    margin: 0 auto;
 }
+
+.btn-move-project-channel{
+  margin: 2em 0;
+  padding: 14px 0;
+}
+
+.admin-form-title{
+  margin: 1em 0;
+}

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -70,8 +70,4 @@ class Admin::ProjectsController < Channels::Admin::BaseController
   def reject_params
     params.require(:project).permit(:reject_reason)
   end
-
-  def move_project_to_channels_params
-    params.require
-  end
 end

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -29,6 +29,11 @@ class Admin::ProjectsController < Channels::Admin::BaseController
     end
   end
 
+  def move_project_to_channel
+    MoveProjectToChannel.new(params[:project_id],params[:channel_id]).call
+    redirect_to :back
+  end
+
   def destroy
     @project = Project.find params[:id]
     if @project.can_push_to_trash?
@@ -64,5 +69,9 @@ class Admin::ProjectsController < Channels::Admin::BaseController
 
   def reject_params
     params.require(:project).permit(:reject_reason)
+  end
+
+  def move_project_to_channels_params
+    params.require
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -80,9 +80,11 @@ class Project < ActiveRecord::Base
   # Used to simplify a has_scope
   scope :successful, ->{ with_state('successful') }
   scope :failed, ->{ with_state('failed') }
+  scope :draft, ->{ with_state('draft') }
+
   scope :with_project_totals, -> { joins('LEFT OUTER JOIN project_totals ON project_totals.project_id = projects.id') }
   scope :without_pepsico_channel, -> { joins(:channels).where.not('"channels"."permalink" = \'pepsico\'') }
-
+  scope :draft_and_without_channel, ->{ draft & without_channel }
   scope :by_progress, ->(progress) { joins(:project_total).where("project_totals.pledged >= projects.goal*?", progress.to_i/100.to_f) }
   scope :by_channel, ->(channel_id) { joins(:channels).where("channels.id = ?", channel_id) }
   scope :by_user_email, ->(email) { joins(:user).where("users.email = ?", email) }

--- a/app/services/move_project_to_channel.rb
+++ b/app/services/move_project_to_channel.rb
@@ -1,0 +1,14 @@
+class MoveProjectToChannel
+  def initialize(project_params,channel_params)
+    @project = Project.find(project_params)
+    @channel = Channel.find(channel_params)
+  end
+
+  def call
+    if project.channels.empty?
+      project.channels << channel
+    end
+  end
+
+  attr_reader :project, :channel
+end

--- a/app/views/juntos_bootstrap/admin/projects/index.html.slim
+++ b/app/views/juntos_bootstrap/admin/projects/index.html.slim
@@ -48,6 +48,15 @@
         .w-col-2.w-col.u-margintop-10
           = form.button :submit, t('channels.admin.filter.submit'), class: 'btn bt-medium'
 
+    = simple_form_for '', url:  move_project_to_channel_admin_projects_path , method: :post do |form|
+      h3.admin-form-title = t('admin.projects.move_projects.title')
+      .w-row
+        .w-col.w-col-5
+          = form.input :project_id, collection: Project.without_channel, label: 'Projetos'
+        .w-col.w-col-5
+          =form.input :channel_id, collection: Channel.all, label: 'Canais'
+        .w-col.w-col-2
+          = form.button :submit, t('admin.actions.move'), class: 'btn btn-move-project-channel'
   br
   br
   = paginate @projects

--- a/app/views/juntos_bootstrap/admin/projects/index.html.slim
+++ b/app/views/juntos_bootstrap/admin/projects/index.html.slim
@@ -51,8 +51,16 @@
     = simple_form_for '', url:  move_project_to_channel_admin_projects_path , method: :post do |form|
       h3.admin-form-title = t('admin.projects.move_projects.title')
       .w-row
+
         .w-col.w-col-5
-          = form.input :project_id, collection: Project.without_channel, label: 'Projetos'
+            = form.input :name,
+              label: t('channels.admin.filter.pg_search') do
+              = select_tag "project_id",
+                options_from_collection_for_select(Project.order(:name).draft_and_without_channel, "id", "name"),
+                class: 'select required w-select text-field',
+                prompt: t('simple_form.prompts.project.select'),
+                required: true,
+                data: 'select2'
         .w-col.w-col-5
           =form.input :channel_id, collection: Channel.all, label: 'Canais'
         .w-col.w-col-2

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -66,6 +66,8 @@ en:
           email: 'E-mail'
           permalink: "Project's permalink"
     projects:
+      move_projects:
+        title: 'Move a project to a channel'
       index:
         with_state: 'By state'
         by_category: 'By category'
@@ -106,6 +108,7 @@ en:
         search_report: 'Export CSV'
     actions:
       confirm: 'Confirm'
+      move: 'Move'
     users:
       index:
         title: 'Donors management'
@@ -212,8 +215,8 @@ en:
         platform_value: 'Amount to the platform'
         project_value: 'Amount to the project'
         partner_indication: 'Partner indication'
-        only_recurring: Only recurring 
-        only_cancelled_recurring: Recurring cancelled 
+        only_recurring: Only recurring
+        only_cancelled_recurring: Recurring cancelled
 
     statistics:
       index:

--- a/config/locales/admin.pt.yml
+++ b/config/locales/admin.pt.yml
@@ -66,6 +66,8 @@ pt:
           email: 'E-mail'
           permalink: 'Permalink do projeto'
     projects:
+      move_projects:
+        title: 'Mover um projeto para um canal'
       index:
         with_state: 'Por estado'
         by_category: 'Por categoria'
@@ -106,6 +108,7 @@ pt:
         search_report: 'Exportar CSV'
     actions:
       confirm: 'Confirmar'
+      move: 'Mover'
     users:
       index:
         title: "Gerenciamento de apoiadores"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,10 @@ Rails.application.routes.draw do
         put 'push_to_draft'
         put 'push_to_trash'
       end
+
+      collection do
+        post :move_project_to_channel
+      end
     end
 
     resources :categories, except: [ :show, :destroy ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,9 +165,8 @@ Rails.application.routes.draw do
         put 'push_to_trash'
       end
 
-      collection do
-        post :move_project_to_channel
-      end
+      post :move_project_to_channel, on: :collection
+
     end
 
     resources :categories, except: [ :show, :destroy ]

--- a/spec/controllers/admin/projects_controller_spec.rb
+++ b/spec/controllers/admin/projects_controller_spec.rb
@@ -126,10 +126,12 @@ RSpec.describe Admin::ProjectsController, type: :controller do
     let (:project) { FactoryGirl.create(:project) }
     let (:channel) { FactoryGirl.create(:channel) }
 
-    it "shouldn't have a channel" do
-      expect {
-        post :move_project_to_channel, { :project_id => project.id, :channel_id => channel.id }
-      }.to change{ project.channels.count }.from(0).to(1)
+    it "Adds project to channel" do
+      expect(channel.projects).to be_empty
+
+      post :move_project_to_channel, { :project_id => project.id, :channel_id => channel.id }
+
+      expect(channel.reload.projects).to include(project)
     end
   end
 

--- a/spec/controllers/admin/projects_controller_spec.rb
+++ b/spec/controllers/admin/projects_controller_spec.rb
@@ -121,5 +121,16 @@ RSpec.describe Admin::ProjectsController, type: :controller do
       end
     end
   end
-end
 
+  describe "POST move_project_to_channel" do
+    let (:project) { FactoryGirl.create(:project) }
+    let (:channel) { FactoryGirl.create(:channel) }
+
+    it "shouldn't have a channel" do
+      expect {
+        post :move_project_to_channel, { :project_id => project.id, :channel_id => channel.id }
+      }.to change{ project.channels.count }.from(0).to(1)
+    end
+  end
+
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -51,6 +51,13 @@ FactoryGirl.define do
     f.first_contributions 'Foo bar'
     f.video_url 'http://vimeo.com/17298435'
     f.state 'online'
+
+    factory :project_with_channel do
+      after(:create) do |project|
+        channel = create :channel
+        project.channels << channel
+      end
+    end
   end
 
   factory :channels_subscriber do |f|

--- a/spec/services/move_project_to_channel_spec.rb
+++ b/spec/services/move_project_to_channel_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe MoveProjectToChannel do
+  describe "#call" do
+    let (:project) { FactoryGirl.create(:project) }
+    let (:channel) { FactoryGirl.create(:channel) }
+    let (:project_with_channel) { FactoryGirl.create(:project_with_channel) }
+
+    context "when project already has channel" do
+      subject { MoveProjectToChannel.new(project_with_channel.id, channel.id) }
+
+      it "doesn't add project to channel" do
+        subject.call
+        expect(project_with_channel.reload.channels).not_to include(channel)
+      end
+    end
+
+    context "when a project doesn't have a channel" do
+      subject { MoveProjectToChannel.new(project.id, channel.id) }
+      it "adds project to channel" do
+        subject.call
+        expect(project.reload.channels).to include(channel)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This pr aim to create a new admin form to move a project to a channel.
**Context:** Sometimes a project was created outside a channel accidentally and there was no way to move a project to a channel.