### PR TITLE
Fix projects with refunded payments

### DIFF
--- a/db/migrate/20161004180821_change_project_total_contribution_types.rb
+++ b/db/migrate/20161004180821_change_project_total_contribution_types.rb
@@ -1,0 +1,17 @@
+class ChangeProjectTotalContributionTypes < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+      CREATE OR REPLACE VIEW project_totals AS
+        SELECT
+          contributions.project_id,
+          sum(contributions.project_value) AS pledged,
+          ((sum(contributions.project_value) / projects.goal) * (100)::numeric) AS progress,
+          sum(contributions.payment_service_fee) AS total_payment_service_fee,
+          count(*) AS total_contributions,
+          sum(contributions.platform_value) AS platform_fee
+        FROM (contributions JOIN projects ON ((contributions.project_id = projects.id)))
+        WHERE ((contributions.state)::text = ANY ((ARRAY['confirmed'::character varying, 'requested_refund'::character varying])::text[]))
+        GROUP BY contributions.project_id, projects.goal;
+      SQL
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -89,6 +89,42 @@ FactoryGirl.define do
     f.state 'confirmed'
     f.credits false
     f.payment_id '1.2.3'
+
+    trait :confirmed do
+      state 'confirmed'
+    end
+
+    trait :requested_refund do
+      state 'requested_refund'
+    end
+
+    trait :pending do
+      state 'pending'
+    end
+
+    trait :waiting_confirmation do
+      state 'waiting_confirmation'
+    end
+
+    trait :canceled do
+      state 'canceled'
+    end
+
+    trait :refunded do
+      state 'refunded'
+    end
+
+    trait :refunded_and_canceled do
+      state 'refunded_and_canceled'
+    end
+
+    trait :deleted do
+      state 'deleted'
+    end
+
+    trait :invalid_payment do
+      state 'invalid_payment'
+    end
   end
 
   factory :payment_notification do |f|

--- a/spec/models/project_total_spec.rb
+++ b/spec/models/project_total_spec.rb
@@ -2,25 +2,25 @@ require 'rails_helper'
 
 RSpec.describe ProjectTotal, type: :model do
   before do
-    @project_id = create(:contribution, value: 10.0, payment_service_fee: 1, state: 'pending').project_id
-    create(:contribution, value: 10.0, payment_service_fee: 1, state: 'confirmed', project_id: @project_id)
-    create(:contribution, value: 10.0, payment_service_fee: 1, state: 'waiting_confirmation', project_id: @project_id)
-    create(:contribution, value: 10.0, payment_service_fee: 1, state: 'refunded', project_id: @project_id)
-    create(:contribution, value: 10.0, payment_service_fee: 1, state: 'requested_refund', project_id: @project_id)
+    @project_id = create(:contribution, :pending, value: 10.0, payment_service_fee: 1).project_id
+    create(:contribution, :confirmed, value: 10.0, payment_service_fee: 1, project_id: @project_id)
+    create(:contribution, :waiting_confirmation, value: 10.0, payment_service_fee: 1, project_id: @project_id)
+    create(:contribution, :refunded, value: 10.0, payment_service_fee: 1, project_id: @project_id)
+    create(:contribution, :requested_refund, value: 10.0, payment_service_fee: 1, project_id: @project_id)
   end
 
   describe "#pledged" do
     subject{ ProjectTotal.where(project_id: @project_id).first.pledged }
-    it{ is_expected.to eq(30) }
+    it{ is_expected.to eq(20) }
   end
 
   describe "#total_contributions" do
     subject{ ProjectTotal.where(project_id: @project_id).first.total_contributions }
-    it{ is_expected.to eq(3) }
+    it{ is_expected.to eq(2) }
   end
 
   describe "#total_payment_service_fee" do
     subject { ProjectTotal.where(project_id: @project_id).first.total_payment_service_fee }
-    it { is_expected.to eq(3) }
+    it { is_expected.to eq(2) }
   end
 end


### PR DESCRIPTION
The project_total.pledge value wasn't according with the expected value because the project_total view was selecting contributions with these states: 'confirmed', 'refunded' and 'requested_refund'. So, the view was replaced for another without the refunded state filter.

Created specs for the new Project#pledged behavior.

Updated specs for the view project_total.

