### PR TITLE
Fix Project's pg_search when used together with user_name_contains

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 's3_direct_upload', github: 'waynehoover/s3_direct_upload'
 # Database and data related
 gem 'pg'
 gem 'postgres-copy'
-gem 'pg_search'
+gem 'pg_search', '~> 1.0.6'
 gem 'i18n_alchemy'
 
 gem 'schema_plus'
@@ -124,7 +124,7 @@ group :production do
   gem 'newrelic_rpm', '3.6.5.130'
 
   gem 'clockwork', '~> 1.0.0'
-  
+
   # Using dalli and memcachier have not presented significative performance gains
   # Probably this is due to our pattern of cache usage
   # + the lack of concurrent procs in our deploy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,7 +377,7 @@ GEM
       multi_json
       rest-client
     pg (0.17.1)
-    pg_search (0.7.8)
+    pg_search (1.0.6)
       activerecord (>= 3.1)
       activesupport (>= 3.1)
       arel
@@ -657,7 +657,7 @@ DEPENDENCIES
   omniauth-twitter
   pagarme (= 2.1.2)
   pg
-  pg_search
+  pg_search (~> 1.0.6)
   poltergeist
   postgres-copy
   protected_attributes (~> 1.0.5)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -77,6 +77,12 @@ class Project < ActiveRecord::Base
     using: {tsearch: {dictionary: "portuguese"}},
     ignoring: :accents
 
+  pg_search_scope :user_name_contains, associated_against: {
+      user: :name
+    },
+    using: {tsearch: {dictionary: "portuguese"}},
+    ignoring: :accents
+
   # Used to simplify a has_scope
   scope :successful, ->{ with_state('successful') }
   scope :failed, ->{ with_state('failed') }
@@ -98,7 +104,6 @@ class Project < ActiveRecord::Base
   scope :recommended, -> { where(recommended: true) }
   scope :in_funding, -> { not_expired.with_states(['online']) }
   scope :name_contains, ->(term) { where("unaccent(upper(name)) LIKE ('%'||unaccent(upper(?))||'%')", term) }
-  scope :user_name_contains, ->(term) { joins(:user).where("unaccent(upper(users.name)) LIKE ('%'||unaccent(upper(?))||'%')", term) }
   scope :near_of, ->(address_state) { where("EXISTS(SELECT true FROM users u WHERE u.id = projects.user_id AND lower(u.address_state) = lower(?))", address_state) }
   scope :to_finish, ->{ expired.with_states(['online', 'waiting_funds']) }
   scope :visible, -> { without_states(['draft', 'rejected', 'deleted', 'in_analysis']) }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -31,6 +31,16 @@ FactoryGirl.define do
     f.password "123456"
     f.email { generate(:email) }
     f.bio "This is Foo bar's biography."
+
+    factory :user_with_projects do
+      transient do
+        projects_count 1
+      end
+
+      after(:create) do |user, evaluator|
+        create_list(:project, evaluator.projects_count, user: user)
+      end
+    end
   end
 
   factory :category do |f|

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -877,4 +877,62 @@ RSpec.describe Project, type: :model do
       it { is_expected.not_to validate_presence_of :category }
     end
   end
+
+  describe 'pg_search scope associating other scopes' do
+    context 'when associated scope joins one table used in associated_against of pg_search' do
+      context 'when there are projects having user that matches the user name searched in user_name_contains scope' do
+        before do
+          john = create(:user, address_city: 'Orange town', name: 'John')
+          steve = create(:user, name: 'Steve')
+          create(:project, user: steve, name: 'Project about fruits')
+          create(:project, user: steve, name: 'Apples', headline: 'Project about Apples')
+          create(:project, user: steve, name: 'Oranges', about: 'Project about Oranges')
+          create(:project, user: john, name: 'Project about Lemons')
+          create(:project, user: user, name: 'Project about Vegetables')
+          create_list :project, 4
+        end
+
+        it 'returns projects with name matching the pg_search term' do
+          projects = Project.pg_search('about fruits').user_name_contains('Steve')
+          expect(projects.map(&:name)).to match(['Project about fruits'])
+        end
+
+        it 'returns projects with headline matching the pg_search term' do
+          projects = Project.pg_search('about apples').user_name_contains('Steve')
+          expect(projects.map(&:name)).to match(['Apples'])
+        end
+
+        it 'returns projects with about attribute matching the pg_search term' do
+          projects = Project.pg_search('about oranges').user_name_contains('Steve')
+          expect(projects.map(&:name)).to match(['Oranges'])
+        end
+
+        it 'returns projects having user\'s address_city attribute matching the pg_search term' do
+          projects = Project.pg_search('orange town').user_name_contains('John')
+          expect(projects.map(&:name)).to match(['Project about Lemons'])
+        end
+
+        it 'returns projects having name, headline and/or about attributes matching the pg_search term' do
+          projects = Project.pg_search('about').user_name_contains('Steve')
+          expect(projects.map(&:name)).to match_array(['Project about fruits', 'Apples', 'Oranges'])
+        end
+
+        it 'ommits projects which do not have name, headline and/or about attributes matching the pg_search term' do
+          projects = Project.pg_search('about fruits').user_name_contains('Steve')
+          expect(projects.map(&:name)).not_to match(['Project about Vegetables'])
+        end
+      end
+
+      context 'when there are not projects with user that matches the user name searched in user_name_contains scope' do
+        before do
+          create(:user_with_projects, projects_count: 1, name: 'John')
+        end
+
+        it 'does not return projects' do
+          projects = Project.pg_search('john').user_name_contains('Steve')
+          expect(projects.count(:all)).to eq(0)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
pg_search's gem on 0.7.8 version was throwing an active record error when two scopes made with pg_search_scope method are chained:
```PG::AmbiguousColumn: ERROR:  ORDER BY "pg_search_rank" is ambiguous```

Problem solved on this PR: https://github.com/Casecommons/pg_search/pull/258

pg_search's gem changelog: https://github.com/Casecommons/pg_search/blob/master/CHANGELOG.md#105

The specs for this case(chain pg_search_scope scopes) was created.