### PR TITLE
Bug when try to remove users from Juntos's team

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -259,7 +259,7 @@ class User < ActiveRecord::Base
   end
 
   def self.staff_descriptions
-    STAFFS.keys.map { |description| User.human_attribute_name("staff/#{description}") }
+    STAFFS.keys.map { |description| User.human_attribute_name("staff.#{description}") }
   end
 
   def approved?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -258,10 +258,8 @@ class User < ActiveRecord::Base
     raw
   end
 
-  def self.staff_array
-    STAFFS.map do |name, value|
-      [User.human_attribute_name("staff/#{name}"), value]
-    end
+  def self.staff_descriptions
+    STAFFS.keys.map { |description| User.human_attribute_name("staff/#{description}") }
   end
 
   def approved?

--- a/app/views/users/_current_user_fields.html.slim
+++ b/app/views/users/_current_user_fields.html.slim
@@ -43,9 +43,13 @@
           - if current_user.try(:admin?)
             .profile
               h3.u-marginbottom-20 Campos do admin
-              = f.input :staffs, as: :select, collection: User.staff_array,
-                label: t('activerecord.attributes.user.staff'), multiple: true
-              = f.input :admin, as: :boolean, label: t('activerecord.attributes.user.admin')
+              .w-col.w-col-12
+                = f.input :admin, as: :boolean, label: t('activerecord.attributes.user.admin'),
+                  input_html: { class: 'w-col w-col-12' }
+              .w-col.w-col-12
+                = f.input :staffs, label: t('activerecord.attributes.user.staff'), as: :check_boxes,
+                  collection: User::STAFFS.values, member_label: Proc.new { |c| User.staff_descriptions[c] },
+                  input_html: { class: 'w-col w-col-12' }
           .socialmidia
             = f.input :moip_login, label: t('activerecord.attributes.user.moip_login')
             = f.input :phone_number, required: false, as: :string

--- a/config/locales/catarse_bootstrap/activerecord.en.yml
+++ b/config/locales/catarse_bootstrap/activerecord.en.yml
@@ -39,6 +39,11 @@ en:
         project: project
       reward:
         deliver_at: Deliver at
+      user/staff:
+        team: 'Team'
+        financial_board: 'Financial council'
+        technical_board: 'Technical council'
+        advice_board: 'Council'
       user:
         address_city: 'City'
         address_complement: 'Complement'
@@ -71,10 +76,6 @@ en:
         gender/male: 'Male'
         gender/female: 'Female'
         staff: 'Staff'
-        staff/team: 'Team'
-        staff/financial_board: 'Financial council'
-        staff/technical_board: 'Technical council'
-        staff/advice_board: 'Council'
         original_doc12_url: 'RG e CPF ou CNH'
         original_doc13_url: 'Proof of residence of the person or institution'
         job_title: 'Role'

--- a/config/locales/catarse_bootstrap/activerecord.pt.yml
+++ b/config/locales/catarse_bootstrap/activerecord.pt.yml
@@ -57,6 +57,11 @@ pt:
         first_contributions: "Quem são as primeiras pessoas que você vai pedir para apoiar o seu projeto?"
         project_partners: 'Parceiros'
         recipient: 'Dados bancários'
+      user/staff:
+        team: 'Time'
+        financial_board: 'Conselho Financeiro'
+        technical_board: 'Conselho Técnico'
+        advice_board: 'Conselho'
       user:
         address_city: Cidade
         address_complement: Complemento
@@ -89,10 +94,6 @@ pt:
         gender/male: 'Masculino'
         gender/female: 'Feminino'
         staff: 'Departamento'
-        staff/team: 'Time'
-        staff/financial_board: 'Conselho Financeiro'
-        staff/technical_board: 'Conselho Técnico'
-        staff/advice_board: 'Conselho'
         original_doc1_url: Estatuto social registrado em cartório
         original_doc2_url: Última ata de assembleia geral registrada em cartório
         original_doc3_url: Último parecer do conselho fiscal

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe User, type: :model do
   let(:successful_project){ create(:project, state: 'online') }
   let(:failed_project){ create(:project, state: 'online') }
   let(:facebook_provider){ create :oauth_provider, name: 'facebook' }
+  let(:staff_attributes) do
+    [
+      User.human_attribute_name('staff.team'),
+      User.human_attribute_name('staff.financial_board'),
+      User.human_attribute_name('staff.technical_board'),
+      User.human_attribute_name('staff.advice_board'),
+    ]
+  end
 
   describe '::STAFFS' do
     it 'defines a constant' do
@@ -39,23 +47,10 @@ RSpec.describe User, type: :model do
     it{ is_expected.to validate_uniqueness_of(:email) }
   end
 
-  describe '.staff_array' do
-    let(:attributes) do
-      [
-        User.human_attribute_name('staff/team'),
-        User.human_attribute_name('staff/financial_board'),
-        User.human_attribute_name('staff/technical_board'),
-        User.human_attribute_name('staff/advice_board'),
-      ]
+  describe '.staff_descriptions' do
+    it "should return an array matching all the STAFF's constant keys" do
+      expect(described_class.staff_descriptions).to match staff_attributes
     end
-
-    let(:expected_array) do
-      attributes.each_with_index.map { |name, index| [name, index] }
-    end
-
-    subject { described_class.staff_array }
-
-    it { is_expected.to match expected_array }
   end
 
   describe ".to_send_category_notification" do


### PR DESCRIPTION
This bug was about the field chosen to select the staff types of an user, the field is a select field and is difficult to select and deselect options(is needed to press ctrl and stuff like that). It was replaced for checkboxes(more easy to use, especially for multiple choices).

I had a problem with the precheck of these checkboxes - made by the formtastic gem - and needed to replace the User method that fill the checkboxes(staffs_array), now the collection passed to the checkboxes builder method is an array with all the staff ids. This method was replaced by User.staff_description(used to fill the label values).
Check this stackoverflow article:  http://stackoverflow.com/questions/32548540/formtastic-pre-check-few-checkboxes

I decided to use the 'user/staff' name key for `human_attribute_name` implementation reasons. Explanation [here](http://www.soulcutter.com/blog/2013/localization-of-nested-attributes-in-rails-3-dot-2/).

Created specs for User.staff_description.
