### PR TITLE
Fix bug on the admin projects view filters

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -58,7 +58,7 @@ class Admin::ProjectsController < Channels::Admin::BaseController
   def unpaginated_collection
     @scoped_projects = apply_scopes(end_of_association_chain).with_project_totals.without_state('deleted')
     if channel
-      @scoped_projects = @scoped_projects.where("id IN (SELECT project_id FROM channels_projects WHERE channel_id = #{channel.id})")
+      @scoped_projects = @scoped_projects.by_channel(channel.id)
     end
     @scoped_projects
   end

--- a/app/views/juntos_bootstrap/admin/projects/index.html.slim
+++ b/app/views/juntos_bootstrap/admin/projects/index.html.slim
@@ -39,7 +39,13 @@
         .w-col-3.w-col
           = form.input :with_state, collection: Project.state_names, label: t('channels.admin.filter.with_state'), as: :select, selected: params[:with_state], include_blank: true, input_html: { class: 'w-input text-field' }
         .w-col-3.w-col
-          = form.input :by_channel, as: :select, collection: Channel.all, selected: params[:by_channel], include_blank: true, input_html: { class: 'w-input text-field' }
+          - if channel
+            = form.input :by_channel, as: :hidden, input_html: { value: channel.id }
+            = form.input :by_channel, as: :select, collection: Channel.all, selected: channel.id,
+              include_blank: true, input_html: { disabled: true, class: 'w-input text-field' }
+          - else
+            = form.input :by_channel, as: :select, collection: Channel.all, selected: params[:by_channel],
+              include_blank: true, input_html: { class: 'w-input text-field' }
 
       .w-row
         .w-col-8.w-col

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -935,4 +935,29 @@ RSpec.describe Project, type: :model do
       end
     end
   end
+
+  describe '#by_channel' do
+    let(:foo_channel){ create(:channel, name: 'Foo Channel', users: [ user ]) }
+    let(:foo_channel_projects){ Project.by_channel(foo_channel.id) }
+
+    before(:each) do
+      create_list(:project, 10)
+    end
+
+    context 'when channel does not have registered projects' do
+      it 'does not return projects' do
+        expect(foo_channel_projects.count).to eq(0)
+      end
+    end
+
+    context 'when channel have registered projects' do
+      before do
+        create(:project, name: 'Project Bar in Foo Channel', channels: [foo_channel])
+      end
+
+      it "should return only projects that belongs to the channel passed as param" do
+        expect(foo_channel_projects.map(&:name)).to match(['Project Bar in Foo Channel'])
+      end
+    end
+  end
 end


### PR DESCRIPTION
When user is inside a channel, for example: http://elos.juntos.com.vc and try to filter projects by channel - what doesn't makes sense, because only projects of the channel supposed to be listed - is raised an ActiveRecord's error, caused by an ambiguous column. To solve this, the select field must be disabled when user is inside a channel and the current channel is selected in channel's select field.
