### PR TITLE
Fix dropdown admin

### DIFF
--- a/app/assets/javascripts/app/admin.js
+++ b/app/assets/javascripts/app/admin.js
@@ -5,10 +5,18 @@ App.addChild('Admin', {
     'click .project-admin-menu' : "toggleAdminMenu",
   },
 
+
   toggleAdminMenu: function(event){
     var link = $(event.target);
+    var path = this.$('.w-dropdown-btn').parent().next();
     this.$dropdown = link.parent().next('.user-menu');
     this.$dropdown.toggleClass('w--open');
+
+    if (path.hasClass('w--open')){
+      path.removeClass('w--open');
+      this.$dropdown.addClass('w--open');
+    }
+
     return false;
   },
 });

--- a/app/assets/stylesheets/juntos_bootstrap/_main.scss
+++ b/app/assets/stylesheets/juntos_bootstrap/_main.scss
@@ -2067,7 +2067,8 @@ p {
 .dropdown-list.user-menu.w--open {
   position: absolute;
   z-index: 10;
-  margin-top: 8px;
+  right: -30px;
+  margin-top: 10px;
   margin-left: -150px;
   min-width: 200px;
 }

--- a/app/views/juntos_bootstrap/admin/users/index.html.slim
+++ b/app/views/juntos_bootstrap/admin/users/index.html.slim
@@ -62,7 +62,7 @@ br
             td= user.user_total ? user.user_total.sum : 0
             td= user.credits
             td.w-col-1.w-col.project-events-dropdown
-              .project-admin-menu.card-infos-bottom-right
+              .project-admin-menu
                 = link_to '', 'javascript:void(0);', data: {toggle: 'dropdown'}, class: 'w-dropdown-btn dropdown-toggle fa fa-sort-down'
               nav.w-dropdown-list.dropdown-list.user-menu
                 = link_to user_path(user), method: :put, class:'w-dropdown-link dropdown-link fontsize-smaller' do


### PR DESCRIPTION
On admin menu dropdown, after click on dropdown icon, the menu icon was hiding behind the menu and adjust the menu dropdown size.

**Before:** 
![gerenciamento de apoiadores](https://cloud.githubusercontent.com/assets/12254845/19646805/ed81bf84-99d9-11e6-9bb4-5abca43ce9d6.png)


**After:**
![gerenciamento de apoiadores2](https://cloud.githubusercontent.com/assets/12254845/19646810/f21216d4-99d9-11e6-8222-9952202f7149.png)


