### PR TITLE
Fix bug on the admin contributions view filters

### DIFF
--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -59,7 +59,7 @@ class Contribution < ActiveRecord::Base
   scope :user_cpf_contains, ->(term) { joins(:user).where("unaccent(upper(users.cpf)) LIKE ('%'||unaccent(upper(?))||'%')", term) }
   scope :payer_email_contains, ->(term) { where("unaccent(upper(payer_email)) LIKE ('%'||unaccent(upper(?))||'%')", term) }
   scope :project_name_contains, ->(term) {
-    where('project_id in (?)', Project.search_on_name(term).map(&:id))
+      where(project_id: Project.search_on_name(term).pluck(:id))
   }
   scope :anonymous, -> { where(anonymous: true) }
   scope :credits, -> { where("credits OR lower(payment_method) = 'credits'") }

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -319,4 +319,35 @@ RSpec.describe Contribution, type: :model do
       end
     end
   end
+
+  describe '#project_name_contains' do
+    let(:great_name_project){ create(:project, name: 'Great project') }
+    let(:great_headline_project){ create(:project, headline: 'Great project') }
+    let(:great_permalink_project){ create(:project, permalink: 'great') }
+    let(:great_project_contributions){ Contribution.project_name_contains('great') }
+
+    before(:each) do
+      create(:contribution, project: great_name_project, project_value: 50)
+      create(:contribution, project: great_headline_project, project_value: 40)
+      create(:contribution, project: great_permalink_project, project_value: 30)
+    end
+
+    context 'when there are contributions made to project that matches the term searched' do
+      it 'returns the contributions made to project found' do
+        expect(great_project_contributions.map(&:project_value)).to contain_exactly(40.0, 30.0, 50.0)
+      end
+
+      it "returns the contributions in the right order of Project.search_on_name's against param rules" do
+        all_great_project_contributions = great_project_contributions.map { |c| c.project_value.to_f }
+        expect(all_great_project_contributions).to eq([50.0, 40.0, 30.0])
+      end
+    end
+
+    context 'when contributions to a project that name matches the term searched do not exist' do
+      it 'does not return contributions' do
+        cool_project_contributions = Contribution.project_name_contains('cool')
+        expect(cool_project_contributions).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
Chain Contributions#only_cancelled_recurring and Contributions#project_name_contains was raising an ActiveRecord's error, caused by ambiguity between project_id columns.
This PR aims to fix this bug making the correct references to the project_id column.