### PR TITLE
Fix after login redirect bug

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,10 @@ class ApplicationController < ActionController::Base
     session[:referal_link]
   end
 
+  def ajax_request?
+    request.xhr? == 0
+  end
+
   private
   def referal_it!
     session[:referal_link] = params[:ref] if params[:ref].present?
@@ -67,7 +71,7 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_user_back_after_login
-    if request.env['REQUEST_URI'].present? && !request.xhr?
+    if request.env['REQUEST_URI'].present? && !ajax_request?
       session[:return_to] = request.env['REQUEST_URI']
     end
   end

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -11,8 +11,11 @@ module Concerns
     end
 
     def auth_error(exception)
-      session[:return_to] = request.env['REQUEST_URI']
       message = exception.message
+
+      unless ajax_request?
+        session[:return_to] = request.env['REQUEST_URI']
+      end
 
       if current_user.nil?
         redirect_to new_user_registration_url, alert: I18n.t('devise.failure.unauthenticated')

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe "Users", type: :feature do
   end
 
   describe "redirect to the last page after login" do
+    let!(:project) { create(:project) }
     before do
-      @project = create(:project)
-      visit project_by_slug_path(permalink: @project.permalink)
+      visit project_by_slug_path(permalink: project.permalink)
       login
     end
 
-    xit { expect(current_path).to eq(project_by_slug_path(permalink: @project.permalink)) }
+    it { expect(current_path).to eq(project_by_slug_path(permalink: project.permalink)) }
   end
 
   describe "the notification tab" do
@@ -31,4 +31,3 @@ RSpec.describe "Users", type: :feature do
     end
   end
 end
-


### PR DESCRIPTION
The implementation of .xhr?(alias for #xml_http_request?) returns 0 when the request made is an ajax request(check [this](https://github.com/rails/rails/issues/16444)). So the verification in the redirect_user_back_after login was updating the session[:return_to] even for ajax requests. This PR aims to fix this problem.
