### PR TITLE
Create model for Plans

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,7 @@ gem 'has_scope', '~> 0.6.0.rc'
 gem 'spectator-validates_email',  require: 'validates_email'
 gem 'video_info', '>= 1.1.1'
 gem 'httparty', '~> 0.6.1' # this version is required by moip gem, otherwise payment confirmation will break
+gem 'enumerize'
 
 # Translations
 gem 'http_accept_language'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,8 @@ GEM
       request_store (~> 1.0)
     enumerate_it (1.2.8)
       activesupport (>= 3.0.0)
+    enumerize (2.0.1)
+      activesupport (>= 3.2)
     erubis (2.7.0)
     eventmachine (1.0.3)
     excon (0.40.0)
@@ -625,6 +627,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   draper
+  enumerize
   ezcrypto
   factory_girl_rails
   fakeweb
@@ -704,4 +707,4 @@ RUBY VERSION
    ruby 2.1.8p440
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,0 +1,12 @@
+class Plan < ActiveRecord::Base
+  attr_accessible :name, :amount, :payment_methods
+
+  extend Enumerize
+  extend ActiveModel::Naming
+
+  enumerize :payment_methods,
+            in: { credit_card: 0, bank_billet: 1 },
+            multiple: true, i18n_scope: "enumerize.plan.payment_methods"
+
+  validates_presence_of :name, :amount, :payment_methods
+end

--- a/config/locales/enumerize.en.yml
+++ b/config/locales/enumerize.en.yml
@@ -1,0 +1,6 @@
+en:
+  enumerize:
+    plan:
+      payment_methods:
+        credit_card: "Credit card"
+        bank_billet: "Bank billet"

--- a/config/locales/enumerize.pt.yml
+++ b/config/locales/enumerize.pt.yml
@@ -1,0 +1,6 @@
+pt:
+  enumerize:
+    plan:
+      payment_methods:
+        credit_card: "Cartão de crédito"
+        bank_billet: "Boleto bancário"

--- a/db/migrate/20161104164112_create_plans.rb
+++ b/db/migrate/20161104164112_create_plans.rb
@@ -1,0 +1,10 @@
+class CreatePlans < ActiveRecord::Migration
+  def change
+    create_table :plans do |t|
+      t.string :name
+      t.decimal :amount
+      t.integer :payment_methods, array: true, default: []
+      t.timestamps
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -273,4 +273,22 @@ FactoryGirl.define do
     f.attachment File.open("#{Rails.root}/spec/support/testimg.png")
     f.previous_attachment File.open("#{Rails.root}/spec/support/testimg.png")
   end
+
+  factory :plan do |f|
+    f.name 'Foo Plan'
+    f.amount 30
+    f.payment_methods [:credit_card, :bank_billet]
+
+    trait :invalid_payment_method do
+      payment_methods [:unknown]
+    end
+
+    trait :with_credit_card do
+      payment_methods [:credit_card]
+    end
+
+    trait :with_bank_billet do
+      payment_methods [:bank_billet]
+    end
+  end
 end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Plan, :type => :model do
+  let(:invalid_payment_method_plan) { build(:plan, :invalid_payment_method) }
+  let(:credit_card_plan) { build(:plan, :with_credit_card) }
+  let(:bank_billet_plan) { build(:plan, :with_bank_billet) }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:amount) }
+    it { is_expected.to validate_presence_of(:payment_methods) }
+    it { is_expected.to enumerize(:payment_methods).in(:credit_card, :bank_billet) }
+
+    context 'when an invalid payment_method value is passed' do
+      it 'should not be valid' do
+        expect(invalid_payment_method_plan).to be_invalid
+      end
+    end
+
+    context 'when the payment_method is valid' do
+      context 'credit_card' do
+        it 'should be valid' do
+          expect(credit_card_plan).to be_valid
+        end
+      end
+
+      context 'bank_billet' do
+        it 'should be valid' do
+          expect(bank_billet_plan).to be_valid
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Was necessary specify the ```attr_accessible``` in Plan's model([here](https://github.com/juntos-com-vc/juntos.com.vc/pull/241/files#diff-e17c11183d250fb09321ae866bd7a4d9R2)) to avoid the Brakeman's warning: ```Brakeman: Mass Assignment not restricted using attr_accessible```