### PR TITLE
Fixed project goal searching

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -157,6 +157,16 @@ class Project < ActiveRecord::Base
 
   scope :without_recurring_and_pepsico_channel, -> { union_scope(with_channel_without_recurring.without_pepsico_channel, without_channel) }
 
+  scope :goal_between, -> (value_starts_at, value_ends_at) do
+    if value_starts_at && value_ends_at
+      where(goal: value_starts_at..value_ends_at)
+    elsif value_starts_at
+      where('goal >= ?', value_starts_at)
+    elsif value_ends_at
+      where('goal <= ?', value_ends_at)
+    end
+  end
+
   attr_accessor :accepted_terms, :new_record
 
   validates_acceptance_of :accepted_terms, on: :create
@@ -183,10 +193,6 @@ class Project < ActiveRecord::Base
     expiring_in_less_of('7 days').find_each do |project|
       project.notify_owner(:verify_moip_account, { from_email: CatarseSettings[:email_payments]})
     end
-  end
-
-  def self.goal_between(starts_at, ends_at)
-    where("goal BETWEEN ? AND ?", starts_at, ends_at)
   end
 
   def self.order_by(sort_field)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -293,17 +293,43 @@ RSpec.describe Project, type: :model do
   end
 
   describe '.goal_between' do
-    let(:start_at) { 100 }
-    let(:ends_at) { 200 }
-    subject { Project.goal_between(start_at, ends_at).order(:id) }
-
     before do
-      @project_01 = create(:project, goal: 100)
-      @project_02 = create(:project, goal: 200)
-      @project_03 = create(:project, created_at: 300)
+      create(:project, goal: 199, name: 'with_goal_199')
+      create(:project, goal: 200, name: 'with_goal_200')
+      create(:project, goal: 300, name: 'with_goal_300')
+      create(:project, goal: 400, name: 'with_goal_400')
+      create(:project, goal: 401, name: 'with_goal_401')
     end
 
-    it { is_expected.to eq([@project_01, @project_02]) }
+    subject { Project.goal_between(start_at, ends_at).map(&:name) }
+
+    context "when there are both start_at and ends_at" do
+      let(:start_at) { 200 }
+      let(:ends_at)  { 300 }
+
+      it { is_expected.to contain_exactly('with_goal_200', 'with_goal_300') }
+    end
+
+    context "when there is only ends_at filter" do
+      let(:start_at) { nil }
+      let(:ends_at)  { 300 }
+
+      it { is_expected.to contain_exactly('with_goal_199', 'with_goal_200', 'with_goal_300') }
+    end
+
+    context "when there is only start_at filter" do
+      let(:start_at) { 200 }
+      let(:ends_at)  { nil }
+
+      it { is_expected.to contain_exactly('with_goal_200', 'with_goal_300', 'with_goal_400', 'with_goal_401') }
+    end
+
+    context "when there is neither start_at and ends_at" do
+      let(:start_at) { nil }
+      let(:ends_at)  { nil }
+
+      it { is_expected.to contain_exactly('with_goal_199', 'with_goal_200', 'with_goal_300', 'with_goal_400', 'with_goal_401') }
+    end
   end
 
 


### PR DESCRIPTION
It was only possible to filter projects for goal if the user enter both minimum and maximum goal values.
Now it is possible to filter projects for minimum, maximum or both goal values.