### PR TITLE
Update plans service

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,5 +1,5 @@
 class Plan < ActiveRecord::Base
-  attr_accessible :name, :amount, :payment_methods
+  attr_accessible :plan_code, :name, :amount, :payment_methods
 
   extend Enumerize
   extend ActiveModel::Naming
@@ -8,5 +8,5 @@ class Plan < ActiveRecord::Base
             in: { credit_card: 0, bank_billet: 1 },
             multiple: true, i18n_scope: "enumerize.plan.payment_methods"
 
-  validates_presence_of :name, :amount, :payment_methods
+  validates_presence_of :plan_code, :name, :amount, :payment_methods
 end

--- a/app/services/recurring_contribution/update_plans.rb
+++ b/app/services/recurring_contribution/update_plans.rb
@@ -1,0 +1,34 @@
+class RecurringContribution::UpdatePlans
+  def self.call
+    new.call
+  end
+
+  def call
+    Plan.transaction do
+      pagarme_plans.map do |plan|
+        build_plan(plan) unless plan_exist?(plan)
+      end.compact
+    end
+  end
+
+  private
+
+  def build_plan(plan)
+    normalize_payment_methods(plan)
+    Plan.create(plan_code: plan.id, name: plan.name, amount: plan.amount, payment_methods: plan.payment_methods)
+  end
+
+  def normalize_payment_methods(plan)
+    if plan.payment_methods.include? 'boleto'
+      plan.payment_methods.each { |payment_method| payment_method.gsub!('boleto', 'bank_billet') }
+    end
+  end
+
+  def pagarme_plans
+    PagarMe::Plan.all
+  end
+
+  def plan_exist?(plan)
+    Plan.exists?(plan_code: plan.id)
+  end
+end

--- a/db/migrate/20161104164112_create_plans.rb
+++ b/db/migrate/20161104164112_create_plans.rb
@@ -1,7 +1,8 @@
 class CreatePlans < ActiveRecord::Migration
   def change
     create_table :plans do |t|
-      t.string :name
+      t.integer :plan_code
+      t.string  :name
       t.decimal :amount
       t.integer :payment_methods, array: true, default: []
       t.timestamps

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -275,6 +275,7 @@ FactoryGirl.define do
   end
 
   factory :plan do |f|
+    f.plan_code { rand(1..100) }
     f.name 'Foo Plan'
     f.amount 30
     f.payment_methods [:credit_card, :bank_billet]

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Plan, :type => :model do
   let(:bank_billet_plan) { build(:plan, :with_bank_billet) }
 
   describe 'validations' do
+    it { is_expected.to validate_presence_of(:plan_code) }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:amount) }
     it { is_expected.to validate_presence_of(:payment_methods) }

--- a/spec/services/recurring_contribution/update_plans_spec.rb
+++ b/spec/services/recurring_contribution/update_plans_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+require 'json'
+
+RSpec.describe RecurringContribution::UpdatePlans do
+  def mocked_plans
+    (1..3).map do |plan_id|
+      build_plan_mock(plan_id)
+    end
+  end
+
+  def build_plan_mock(plan_id)
+    double("Plan", id: plan_id,
+                   name: 'Foo Plan',
+                   amount: 30,
+                   payment_methods: ['boleto', 'credit_card'])
+  end
+
+  describe '#call' do
+    let(:remote_plans) { mocked_plans }
+    let(:update_plans_service) { RecurringContribution::UpdatePlans.call }
+    let(:local_plans) { Plan.all }
+
+    before(:each) do
+      allow_any_instance_of(described_class).to receive(:pagarme_plans) { mocked_plans }
+    end
+
+    context "when there are remote plans that not exist in junto's database" do
+      it 'must create the plans' do
+        update_plans_service
+        expect(remote_plans.map(&:id)).to match_array(local_plans.map(&:plan_code))
+      end
+    end
+
+    context 'when all plans are updated' do
+      before do
+        allow_any_instance_of(described_class).to receive(:plan_exist?) { true }
+      end
+
+      it 'should return an empty array' do
+        returned_value = update_plans_service
+        expect(returned_value).to be_empty
+      end
+    end
+
+    context 'when ActiveRecord raises an error on Plan creation' do
+      before do
+        allow_any_instance_of(described_class).to receive(:build_plan) { raise ActiveRecord::Rollback }
+      end
+
+      it "does not create the plans returned from PagarMe's API" do
+        expect { update_plans_service }.to_not change { Plan.count }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This service will synchronize all PagarMe's API Plans made for recurring contributions subscriptions in the application's database.