### PR TITLE
Channel categories

### DIFF
--- a/app/controllers/admin/channels_controller.rb
+++ b/app/controllers/admin/channels_controller.rb
@@ -3,27 +3,12 @@ class Admin::ChannelsController < Admin::BaseController
   inherit_resources
   defaults resource_class: Channel, collection_name: 'channels', instance_name: 'channel'
 
+  def create
+    create! { admin_channels_path }
+  end
+
   def update
     update! { admin_channels_path }
-  end
-
-  def new
-    super
-    binding.pry
-  end
-
-  def create
-    @profile = Channel.new channel_params
-    binding.pry
-    if @profile.save
-      redirect_to admin_channels_path
-    else
-      render :new
-    end
-  end
-
-  def channel_params
-    params.require(:channel).permit(:name, :permalink, :recurring, :custom_submit_text, :description, :category_id)
   end
 
 end

--- a/app/controllers/admin/channels_controller.rb
+++ b/app/controllers/admin/channels_controller.rb
@@ -3,12 +3,27 @@ class Admin::ChannelsController < Admin::BaseController
   inherit_resources
   defaults resource_class: Channel, collection_name: 'channels', instance_name: 'channel'
 
-  def create
-    create! { admin_channels_path }
-  end
-
   def update
     update! { admin_channels_path }
+  end
+
+  def new
+    super
+    binding.pry
+  end
+
+  def create
+    @profile = Channel.new channel_params
+    binding.pry
+    if @profile.save
+      redirect_to admin_channels_path
+    else
+      render :new
+    end
+  end
+
+  def channel_params
+    params.require(:channel).permit(:name, :permalink, :recurring, :custom_submit_text, :description, :category_id)
   end
 
 end

--- a/app/controllers/channels/profiles_controller.rb
+++ b/app/controllers/channels/profiles_controller.rb
@@ -22,8 +22,8 @@ class Channels::ProfilesController < Channels::BaseController
 
   def create
     @profile = Channel.new channel_params
-    binding.pry
     if @profile.save
+      CreateMultiCategoriesChannel.new(params[:category_id], @profile).call
       redirect_to :back
     else
       render :new

--- a/app/controllers/channels/profiles_controller.rb
+++ b/app/controllers/channels/profiles_controller.rb
@@ -20,10 +20,25 @@ class Channels::ProfilesController < Channels::BaseController
     @profile ||= channel
   end
 
+  def create
+    @profile = Channel.new channel_params
+    binding.pry
+    if @profile.save
+      redirect_to :back
+    else
+      render :new
+    end
+  end
+
   private
   def show_statistics
     @total_pledged = resource.projects.map(&:project_total).compact.sum(&:pledged).to_f
     @total_projects = resource.projects.count
     @total_contributions = resource.projects.joins(:contributions).count
   end
+
+  def channel_params
+    params.require(:channel).permit(:name, :permalink, :recurring, :custom_submit_text, :description, category_id:  [])
+  end
+
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,6 +3,7 @@ class Category < ActiveRecord::Base
   has_many :projects
   has_many :category_followers
   has_many :users, through: :category_followers
+  has_and_belongs_to_many :channels
 
   validates_presence_of :name_pt
   validates_uniqueness_of :name_pt
@@ -42,7 +43,7 @@ class Category < ActiveRecord::Base
   end
 
   def self.name_with_locale
-    "name_#{I18n.locale}" 
+    "name_#{I18n.locale}"
   end
 
   def name_with_locale

--- a/app/models/category_channel.rb
+++ b/app/models/category_channel.rb
@@ -1,0 +1,2 @@
+class CategoryChannel < ActiveRecord::Base
+end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -9,14 +9,13 @@ class Channel < ActiveRecord::Base
   validates_presence_of :name, :description, :permalink
   validates_uniqueness_of :permalink
 
-  validates_presence_of :category_id, unless: :recurring?
 
   has_and_belongs_to_many :projects, -> { order_status.most_recent_first }
   has_many :subscribers, class_name: 'User', through: :channels_subscribers, source: :user
   has_many :channels_subscribers
   has_many :subscriber_reports
   has_many :users
-  belongs_to :category
+  has_and_belongs_to_many :categories
 
   catarse_auto_html_for field: :how_it_works, video_width: 560, video_height: 340
   catarse_auto_html_for field: :terms, video_width: 560, video_height: 340

--- a/app/services/create_multi_categories_channel.rb
+++ b/app/services/create_multi_categories_channel.rb
@@ -1,0 +1,11 @@
+class CreateMultiCategoriesChannel
+  def initialize(category_ids, channel)
+    @channel = channel
+    @categories = category_ids
+  end
+
+  def call
+    @channel.categories = Category.where(id: @categories)
+    @channel.save
+  end
+end

--- a/app/views/juntos_bootstrap/projects/new.html.slim
+++ b/app/views/juntos_bootstrap/projects/new.html.slim
@@ -50,7 +50,9 @@
                 .fontsize-small.fontcolor-secondary.u-marginbottom-10= form.hint :category
                 = form.association :category, as: :select, collection: Category.order(:name_pt), prompt: t('simple_form.prompts.project.category'), class: 'medium', label: '', hint: ''
             - elsif !channel.recurring?
-              = form.input :category_id, as: :hidden, input_html: {value: channel.category.id}
+              = form.label :category, class: 'fontsize-large', required: false
+              .fontsize-small.fontcolor-secondary.u-marginbottom-10= form.hint :category
+              = form.association :category,  as: :select, collection: channel.categories.map(&:name_pt), class: 'medium', label: '', hint: ''
             .u-marginbottom-40
               = form.label :permalink, class: 'fontsize-large', required: false, as: :string
               .fontsize-small.fontcolor-secondary.u-marginbottom-10= form.hint :permalink

--- a/db/migrate/20161107131252_create_categories_channels.rb
+++ b/db/migrate/20161107131252_create_categories_channels.rb
@@ -1,0 +1,8 @@
+class CreateCategoriesChannels < ActiveRecord::Migration
+  def change
+    create_table :categories_channels do |t|
+      t.integer :category_id
+      t.integer :channel_id
+    end
+  end
+end

--- a/db/migrate/20161109130035_remove_category_id_from_channels.rb
+++ b/db/migrate/20161109130035_remove_category_id_from_channels.rb
@@ -1,0 +1,5 @@
+class RemoveCategoryIdFromChannels < ActiveRecord::Migration
+  def change
+    remove_column :channels, :category_id
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -206,7 +206,6 @@ FactoryGirl.define do
   end
 
   factory :channel do |f|
-    f.association :category
     name "Test"
     email "email+channel@foo.bar"
     description "Lorem Ipsum"

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Channel, type: :model do
   describe "Validations & Assoaciations" do
 
-    [:name, :description, :permalink, :category_id].each do |attribute|
+    [:name, :description, :permalink].each do |attribute|
       it { is_expected.to validate_presence_of      attribute }
       it { is_expected.to allow_mass_assignment_of  attribute }
     end
@@ -106,9 +106,8 @@ RSpec.describe Channel, type: :model do
   end
 
   describe '.recurring' do
-    let(:category) { create :category }
     let(:recurring_channels) { create_list :channel, 2, recurring: true }
-    let(:normal_channels) { create_list :channel, 2, category: category }
+    let(:normal_channels) { create_list :channel, 2 }
 
     subject { described_class.recurring true }
 
@@ -117,10 +116,6 @@ RSpec.describe Channel, type: :model do
   end
 
   context 'when it is a recurring channel' do
-    subject { create :channel, recurring: true, category: nil }
-
-    describe 'validations' do
-      it { is_expected.not_to validate_presence_of :category }
-    end
+    subject { create :channel, recurring: true }
   end
 end

--- a/spec/services/create_multi_categories_channel.rb
+++ b/spec/services/create_multi_categories_channel.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe CreateMultiCategoriesChannel do
+  describe "#call" do
+    let! (:channel) { FactoryGirl.create(:channel) }
+    let! (:category) { FactoryGirl.create(:category) }
+
+    subject { CreateMultiCategoriesChannel.new(category, channel) }
+
+    it "Add a category into a channel" do
+      subject.call
+      expect(channel.categories.reload.count).to be(1)
+    end
+  end
+end


### PR DESCRIPTION
**Context:** Before a channel could had just one category, now a channel can have more than one. To do this I've created a has_and_belongs_to_many association in both models, I prefer create this kind of relation than create a has_many through. After this I created a migration to remove category_id from channels table and I created a new service called CreateMultiCategoriesChannel that recives two params, the first is an arrays with the categories_id and the second the channel.The service is responsible to insert an arrays of categories in the channel.categories
