### PR TITLE
added available_for_contribution flag to project

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -243,7 +243,7 @@ class Project < ActiveRecord::Base
   end
 
   def accept_contributions?
-    online? && !expired?
+    online? && !expired? && available_for_contribution?
   end
 
   def reached_goal?

--- a/app/views/catarse_bootstrap/projects/show.html.slim
+++ b/app/views/catarse_bootstrap/projects/show.html.slim
@@ -75,10 +75,11 @@ section.section
 .w-container
   .w-row
     article
-      #project_basics.content.w-hidden
-        = render 'project_basics'
-      #dashboard_project.content.w-hidden
-        = render 'dashboard_project'
+      - if policy(@project).update?
+        #project_basics.content.w-hidden
+          = render 'project_basics'
+        #dashboard_project.content.w-hidden
+          = render 'dashboard_project'
       #project_about.content.w-col.w-col-8 = render 'project_about'
 
       #project_posts.content.w-col.w-col-8.w-hidden[data-path=project_posts_path(project_id: @project.id)]
@@ -123,7 +124,7 @@ section.section
               .fontsize-largest = @project.remaining_days
               .fontsize-small #{@project.time_to_go[:unit].capitalize} #{pluralize_without_number(@project.time_to_go[:time], t('remaining_singular'), t('remaining_plural'))}
 
-        - if @project.online? && !@project.expired?
+        - if @project.accept_contributions?
           = link_to t('.contribute_project.submit'), new_project_contribution_path(@project), id: 'contribute_project_form', class: "btn btn-large u-marginbottom-20"
 
         .fontsize-smaller.u-marginbottom-30[class=@project.display_card_class]

--- a/app/views/juntos_bootstrap/projects/_project_basics.html.slim
+++ b/app/views/juntos_bootstrap/projects/_project_basics.html.slim
@@ -14,7 +14,7 @@
         .w-col.w-col-8.w-hidden-small.w-hidden-tiny
           .w-form
               = render 'devise/shared/alert'
-              - if (current_user && current_user.admin?) || (current_user && channel && channel.users.include?(current_user))
+              - if current_user.admin? || (channel && channel.users.include?(current_user))
                 - if @project.in_analysis? || current_user.admin?
                   .w-row.card.card-terciary.u-marginbottom-20
                     .w-col.w-col-5
@@ -87,7 +87,14 @@
                         = form.input_field :online_days, class: 'prefix positive', as: :string
                       .w-col.w-col-4.w-col-small-6.w-col-tiny-6.text-field.postfix.no-hover
                         .fontcolor-secondary.u-text-center.fontsize-base.lineheight-tightest = t('.online_days_addon')
-              
+              - if current_user.admin?
+                .w-row.u-marginbottom-30.card.card-terciary
+                  .w-col.w-col-5.w-sub-col
+                    label.field-label.fontweight-semibold for="name-8"=t('.available_for_contributions')
+                    label.field-label.fontsize-smallest.fontcolor-secondary for="name-8"= t('.available_for_contributions_label')
+                  .w-col.w-col-7
+                        = form.input :available_for_contribution, as: :boolean, label: '', input_html: { class: 'w-col w-col-12' }
+
         = render 'project_sidebar_faq'
 
   .divider

--- a/app/views/juntos_bootstrap/projects/show.html.slim
+++ b/app/views/juntos_bootstrap/projects/show.html.slim
@@ -128,10 +128,11 @@ nav.project-nav.w-hidden-main.w-hidden-medium
 .w-container
   .w-row
     article
-      #project_basics.content.w-hidden.w-hidden-small.w-hidden-tiny
-        = render 'project_basics'
-      #dashboard_project.content.w-hidden
-        = render 'dashboard_project'
+      - if policy(@project).update?
+        #project_basics.content.w-hidden.w-hidden-small.w-hidden-tiny
+          = render 'project_basics'
+        #dashboard_project.content.w-hidden
+          = render 'dashboard_project'
 
       #rewards.w-col.w-col-8.w-hidden
         #project-sidebar-mobile.aside.w-col.w-col-4.rewards-space
@@ -210,11 +211,11 @@ nav.project-nav.w-hidden-main.w-hidden-medium
             .fontsize-large.fontweight-light.u-margintop-30
               = t('.contribute_project.already_contributing')
             .fontsize-smallest.fontweight-light.u-marginbottom-30
-              = link_to t('.contribute_project.cancel'), 
-                  cancel_recurring_project_path(@project), 
+              = link_to t('.contribute_project.cancel'),
+                  cancel_recurring_project_path(@project),
                   data: { confirm: t('.contribute_project.confirm') }
         - else
-          - if @project.online? && !@project.expired? && @project.id != 629
+          - if @project.accept_contributions?
             - if project_aumigo
               = link_to t('.contribute_project.submit'), 'http://acaochego.doemaisdoemelhor.org.br/br/doacao/1/acaochego/aumigo-seu-apoio-e-nossa-esperanca', id: 'contribute_project_form', class: "btn bt-yellow btn-large u-marginbottom-20", target: '_blank'
             - else

--- a/config/locales/catarse_bootstrap/views/projects/show.en.yml
+++ b/config/locales/catarse_bootstrap/views/projects/show.en.yml
@@ -53,6 +53,8 @@ en:
       online_days: 'Deadline for the raising'
       online_days_label: 'On average the projects are aired for 40 days. The maximum campaign period is 60 days.'
       online_days_addon: 'days'
+      available_for_contributions: 'Available for online contributions?'
+      available_for_contributions_label: 'Check the box to allow users to contribute to this project.'
       value: 'Amount to the raised'
       value_secondary: 'A great part of the support will be from people close to you. Think about how to get at least 50% of the target value within your network.'
       bank_account_job_running_title: 'Warning: '

--- a/config/locales/catarse_bootstrap/views/projects/show.pt.yml
+++ b/config/locales/catarse_bootstrap/views/projects/show.pt.yml
@@ -53,6 +53,8 @@ pt:
       online_days: 'Prazo para arrecadação'
       online_days_label: 'Em média os projetos ficam no ar por 40 dias. O prazo máximo da campanha é de 60 dias.'
       online_days_addon: 'dias'
+      available_for_contributions: 'Disponível para receber contribuições online?'
+      available_for_contributions_label: 'Marque a opção para que os usuários possam contribuir para este projeto.'
       value: 'Valor a ser arrecadado'
       value_secondary: 'Grande parte dos apoios serão de pessoas próximas a você. Pense como conseguir pelo menos 50% do valor da meta dentro da sua rede de contatos.'
       bank_account_job_running_title: 'Atenção:'

--- a/db/migrate/20161109220349_add_available_for_contribution_flag_for_project.rb
+++ b/db/migrate/20161109220349_add_available_for_contribution_flag_for_project.rb
@@ -1,0 +1,5 @@
+class AddAvailableForContributionFlagForProject < ActiveRecord::Migration
+  def change
+    add_column :projects, :available_for_contribution, :boolean, default: true
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -84,6 +84,16 @@ FactoryGirl.define do
     trait :online do
       state 'online'
     end
+
+    trait :expired do
+      online_date 10.days.ago
+      online_days 1
+    end
+
+    trait :not_expired do
+      online_date Date.current
+      online_days 10
+    end
   end
 
   factory :channels_subscriber do |f|

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -689,6 +689,36 @@ RSpec.describe Project, type: :model do
     it { is_expected.to eq([reward_01, reward_03]) }
   end
 
+  describe '#accept_contributions?' do
+    context 'when project is online' do
+      context 'and is not expired' do
+        context 'and is available for contribution' do
+          let(:project) { create(:project, :online, :not_expired, available_for_contribution: true) }
+
+          it { expect(project).to be_accept_contributions }
+        end
+
+        context 'and not available for contribution' do
+          let(:project) { create(:project, :online, :not_expired, available_for_contribution: false) }
+
+          it { expect(project).not_to be_accept_contributions }
+        end
+      end
+
+      context 'and is expired' do
+        let(:project) { create(:project, :online, :expired, available_for_contribution: true) }
+
+        it { expect(project).not_to be_accept_contributions }
+      end
+    end
+
+    context 'when project is not online' do
+      let(:project) { create(:project, state: 'failed') }
+
+      it { expect(project).not_to be_accept_contributions }
+    end
+  end
+
   describe "#last_channel" do
     let(:channel){ create(:channel) }
     let(:project){ create(:project, channels: [ create(:channel), channel ]) }


### PR DESCRIPTION
* The flag indicates if the project is available for online contributions.
* If so, the `Support Project` button is visible for the users.
* The admin user may manage the project contribution availability on the `about` tab.