### PR TITLE
Refactoring subscription service

### DIFF
--- a/app/factories/subscription_factory.rb
+++ b/app/factories/subscription_factory.rb
@@ -1,0 +1,49 @@
+class SubscriptionFactory
+  class << self
+    def build(type, plan, user, payment_method, project = nil)
+      new(type, plan, user, payment_method, project).build
+    end
+
+    private :new
+  end
+
+  def initialize(type, plan, user, payment_method, project)
+    @type = type
+    @plan = plan
+    @user = user
+    @payment_method = payment_method
+    @project = project
+  end
+
+  def build
+    case @type
+    when :juntos
+      build_juntos_subscription
+    when :pagarme
+      build_pagarme_subscription
+    end
+  end
+
+  private
+
+  def build_juntos_subscription
+    Subscription.new(plan: @plan, user: @user, payment_method: @payment_method, project: @project)
+  end
+
+  def build_pagarme_subscription
+    PagarMe::Subscription.new({
+      plan: RecurringContribution::PagarmeAPI.find_plan(@plan.plan_code),
+      payment_method: normalize_payment_method(@payment_method),
+      postback_url: "http://test.com/postback",
+      customer: { email: @user.email }
+      })
+  end
+
+  def normalize_payment_method(payment_method)
+    bank_billet? ? 'boleto' : payment_method
+  end
+
+  def bank_billet?
+    @payment_method == 'bank_billet'
+  end
+end

--- a/app/services/recurring_contribution/juntos_subscription.rb
+++ b/app/services/recurring_contribution/juntos_subscription.rb
@@ -1,25 +1,18 @@
 class RecurringContribution::JuntosSubscription
-  def initialize(project, plan, user, payment_method)
-    @project = project
-    @plan = plan
-    @user = user
-    @payment_method = payment_method
+  def initialize(juntos_subscription, pagarme_subscription)
+    @pagarme_subscription = pagarme_subscription
+    @juntos_subscription = juntos_subscription
   end
 
-  def process(pagarme_subscription)
+  def process
     Subscription.transaction do
-      juntos_subscription = create_subscription(pagarme_subscription)
-      juntos_subscription.transactions.build(transaction_code: pagarme_subscription.current_transaction.id,
-                                             status: pagarme_subscription.current_transaction.status,
-                                             amount: pagarme_subscription.current_transaction.amount)
-      juntos_subscription
+      @juntos_subscription.subscription_code = @pagarme_subscription.id
+      @juntos_subscription.status = @pagarme_subscription.status
+      @juntos_subscription.save
+      @juntos_subscription.transactions.build(transaction_code: @pagarme_subscription.current_transaction.id,
+                                              status: @pagarme_subscription.current_transaction.status,
+                                              amount: @pagarme_subscription.current_transaction.amount)
+      @juntos_subscription
     end
-  end
-
-  private
-
-  def create_subscription(pagarme_subscription)
-    Subscription.create(subscription_code: pagarme_subscription.id, status: pagarme_subscription.status,
-                        payment_method: @payment_method, plan: @plan, project: @project, user: @user)
   end
 end

--- a/app/services/recurring_contribution/pagarme_subscription.rb
+++ b/app/services/recurring_contribution/pagarme_subscription.rb
@@ -1,12 +1,10 @@
 class RecurringContribution::PagarmeSubscription
-  def initialize(plan_id, user, payment_method, credit_card)
+  def initialize(pagarme_subscription, credit_card)
     @credit_card = credit_card
-    @payment_method = normalize_payment_method(payment_method)
-    @plan_id = plan_id
-    @user = user
+    @pagarme_subscription = pagarme_subscription
   end
 
-  def build
+  def process
     RecurringContribution::PagarmeAPI.create_subscription(attributes)
   end
 
@@ -18,27 +16,14 @@ class RecurringContribution::PagarmeSubscription
   end
 
   def default_attributes
-    {
-      plan: RecurringContribution::PagarmeAPI.find_plan(@plan_id),
-      payment_method: @payment_method,
-      postback_url: "http://test.com/postback",
-      customer: { email: @user.email }
-    }
+    @pagarme_subscription.instance_values
   end
 
   def credit_card_attributes
     @credit_card.slice(:card_number, :card_holder_name, :card_expiration_month, :card_expiration_year, :card_cvv)
   end
 
-  def normalize_payment_method(payment_method)
-    bank_billet? ? 'boleto' : payment_method
-  end
-
   def credit_card?
     @payment_method == 'credit_card'
-  end
-
-  def bank_billet?
-    @payment_method == 'bank_billet'
   end
 end

--- a/spec/services/recurring_contribution/juntos_subscription_spec.rb
+++ b/spec/services/recurring_contribution/juntos_subscription_spec.rb
@@ -7,11 +7,14 @@ RSpec.describe RecurringContribution::JuntosSubscription do
     let(:project) { create(:project) }
     let(:plan) { create(:plan) }
     let(:user) { create(:user) }
-    let(:juntos_subscription_service) { RecurringContribution::JuntosSubscription.new(project, plan, user, 'credit_card') }
+    let(:juntos_subscription_instance) { SubscriptionFactory.build(:juntos, plan, user, 'credit_card', project) }
 
     context 'when the models subscription and transaction are successfully created' do
       let(:pagarme_subscription) { build_subscription_mock('credit_card') }
-      let(:juntos_subscription)  { juntos_subscription_service.process(pagarme_subscription) }
+      let(:juntos_subscription_service) {
+        RecurringContribution::JuntosSubscription.new(juntos_subscription_instance, pagarme_subscription)
+      }
+      let(:juntos_subscription)  { juntos_subscription_service.process }
 
       it 'must create a subscription model' do
         expect(juntos_subscription.subscription_code).to eq(pagarme_subscription.id)
@@ -26,7 +29,10 @@ RSpec.describe RecurringContribution::JuntosSubscription do
 
     context 'when a problem occurs on creation of models subscription and transaction' do
       let(:invalid_pagarme_subscription) { build_subscription_mock('invalid_payment_method') }
-      let(:invalid_juntos_subscription)  { juntos_subscription_service.process(invalid_pagarme_subscription) }
+      let(:juntos_subscription_service) {
+        RecurringContribution::JuntosSubscription.new(juntos_subscription_instance, invalid_pagarme_subscription)
+      }
+      let(:invalid_juntos_subscription)  { juntos_subscription_service.process }
 
       it 'should not create a subscription model' do
         expect(Subscription.count).to eq(0)

--- a/spec/services/recurring_contribution/pagarme_subscription_spec.rb
+++ b/spec/services/recurring_contribution/pagarme_subscription_spec.rb
@@ -3,15 +3,17 @@ require 'rails_helper'
 RSpec.describe RecurringContribution::PagarmeSubscription do
   include RecurringContributionsHelper
 
-  describe '#build' do
+  describe '#process' do
     let(:plan) { create(:plan, plan_code: 73197) }
     let(:user) { create(:user) }
     let(:credit_card) { build(:credit_card) }
+    let(:credit_card_subscription_instance) { SubscriptionFactory.build(:pagarme, plan, user, 'credit_card') }
+    let(:bank_billet_subscription_instance) { SubscriptionFactory.build(:pagarme, plan, user, 'bank_billet') }
     let(:pagarme_bank_billet_subscription) {
-      RecurringContribution::PagarmeSubscription.new(plan.plan_code, user, 'bank_billet', credit_card).build
+      RecurringContribution::PagarmeSubscription.new(bank_billet_subscription_instance, credit_card).process
     }
     let(:pagarme_credit_card_subscription) {
-      RecurringContribution::PagarmeSubscription.new(plan.plan_code, user, 'credit_card', credit_card).build
+      RecurringContribution::PagarmeSubscription.new(credit_card_subscription_instance, credit_card).process
     }
 
     context 'when the subscription is successfully created' do


### PR DESCRIPTION
Factories were added to project to avoid code duplication in recurring contribution's service. This PR is an attempt to make the services's code more cleaner.