### PR TITLE
Updating the online_days project attribute validations

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -177,7 +177,7 @@ class Project < ActiveRecord::Base
   validates_presence_of :about, :headline, :goal, if: ->(p) {p.state == 'online'}
   validates_length_of :about, minimum: 1
   validates_length_of :headline, maximum: 140, minimum: 1
-  validates_numericality_of :online_days, less_than_or_equal_to: 60, greater_than: 0, if: ->(p){ p.online_days.present? }
+  validates_numericality_of :online_days, greater_than: 0, if: ->(p){ p.online_days.present? }
   validates_numericality_of :goal, greater_than: 9, allow_blank: true
   validates_uniqueness_of :permalink, case_sensitive: false
   validates_format_of :permalink, with: /\A(\w|-)*\Z/

--- a/app/services/project/create.rb
+++ b/app/services/project/create.rb
@@ -1,0 +1,8 @@
+class Project::Create < Project::Crud
+  attr_reader :project
+
+  def initialize(current_user, params)
+    super(current_user, params)
+    @project = Project.new(params)
+  end
+end

--- a/app/services/project/crud.rb
+++ b/app/services/project/crud.rb
@@ -1,0 +1,36 @@
+class Project::Crud
+  MAX_ONLINE_DAYS = 60
+
+  def initialize(current_user, params)
+    @current_user = current_user
+    @params = params
+  end
+
+  def valid?
+    project.valid?
+    unless @current_user.admin?
+      validate_online_days
+    end
+
+    project.errors.empty?
+  end
+
+  def process
+    return false unless valid?
+    project.save
+  end
+
+  private
+
+  def project
+    raise NotImplementedError
+  end
+
+  def validate_online_days
+    project.errors.add(:online_days, :less_than_or_equal_to) if online_days_param > MAX_ONLINE_DAYS
+  end
+
+  def online_days_param
+    @params['online_days'].to_i
+  end
+end

--- a/app/services/project/update.rb
+++ b/app/services/project/update.rb
@@ -1,0 +1,9 @@
+class Project::Update < Project::Crud
+  attr_reader :project
+
+  def initialize(current_user, params, project)
+    super(current_user, params)
+    @project = project
+    @project.attributes = @params
+  end
+end

--- a/app/views/juntos_bootstrap/projects/_project_basics.html.slim
+++ b/app/views/juntos_bootstrap/projects/_project_basics.html.slim
@@ -74,6 +74,8 @@
                   .w-col.w-col-5.w-sub-col
                     label.field-label.fontweight-semibold for="name-8"=t('.online_days')
                     label.field-label.fontsize-smallest.fontcolor-secondary for="name-8"= t('.online_days_label')
+                    - if current_user.admin?
+                      p = form.hint :admin_online_days
                   .w-col.w-col-7
                     .w-row
                       .w-col.w-col-8.w-col-small-6.w-col-tiny-6

--- a/app/views/juntos_bootstrap/projects/new.html.slim
+++ b/app/views/juntos_bootstrap/projects/new.html.slim
@@ -42,6 +42,9 @@
             - unless channel && channel.recurring?
               .u-marginbottom-40
                 = form.label :online_days, class: 'fontsize-large', required: true, as: :string
+                p = form.hint :online_days
+                - if current_user.admin?
+                  p = form.hint :admin_online_days
                 .fontsize-small.fontcolor-secondary.u-marginbottom-10= form.hint :name
                 = form.input_field :online_days, class: 'medium', as: :string
             - if !channel.present?

--- a/config/locales/catarse_bootstrap/activerecord.en.yml
+++ b/config/locales/catarse_bootstrap/activerecord.en.yml
@@ -84,7 +84,7 @@ en:
         channels: 'Channels'
         category: 'Category'
         expires_at: 'Expires at'
-        online_days: 'How many days do you need in order to achieve your goal? The maximum time is 60 days.'
+        online_days: 'Online days number'
         headline: 'A soundbite about your project. 140 characters at most.'
         image_url: 'Image URL'
         name: 'Name of the project'
@@ -115,7 +115,7 @@ en:
             online_days:
               greater_than: "The project's deadline should be greater than 0"
               not_a_number: "The project's deadline should be a number"
-              less_than_or_equal_to: "The project's deadline should be less than or equals to 60 days"
+              less_than_or_equal_to: "must be less than or equals to 60 days"
             about:
               blank: "The project's description cannot be blank"
               too_short: "The project's description is too short. Please, use at least 1 character"

--- a/config/locales/catarse_bootstrap/activerecord.pt.yml
+++ b/config/locales/catarse_bootstrap/activerecord.pt.yml
@@ -43,7 +43,7 @@ pt:
         channels: Canais
         category: Categoria
         expires_at: Prazo
-        online_days: "Quantos dias você precisa para atingir sua meta? O tempo máximo é de 60 dias"
+        online_days: "Quantidade de dias online"
         headline: "Uma frase de efeito sobre o seu projeto. Máximo de 140 caracteres."
         image_url: "URL da imagem"
         name: "Nome do projeto"
@@ -188,7 +188,7 @@ pt:
             online_days:
               greater_than: "O prazo para arrecadação deve ser maior que 0 dias"
               not_a_number: "O prazo para arrecadação deve ser um número de dias"
-              less_than_or_equal_to: "O prazo para arrecadação deve ser menor que 60 dias"
+              less_than_or_equal_to: "deve ser menor que 60 dias"
             about:
               blank: "A descrição do projeto não pode ficar em branco"
               too_short: "A descrição do projeto é muito curta. Por favor, use no mínimo 1 caractere"

--- a/config/locales/catarse_bootstrap/simple_form.en.yml
+++ b/config/locales/catarse_bootstrap/simple_form.en.yml
@@ -57,3 +57,5 @@ en:
         video_url: "Insira aqui o link do seu vídeo. Ele deve estar hospedado no Youtube ou no Vimeo. Se ainda não o tiver, tudo bem, você pode adicioná-lo depois. O vídeo é muito importante para o sucesso de sua campanha e obrigatório para projetos com metas de R$ 5.000 ou mais."
         about: '(Do not worry, you can change it later)'
         headline: '(Do not worry, you can change it later)'
+        online_days: "How many days do you need in order to achieve your goal? The maximum time is 60 days."
+        admin_online_days: "(As a Juntos' administrator you can insert a value greater than 60)"

--- a/config/locales/catarse_bootstrap/simple_form.pt.yml
+++ b/config/locales/catarse_bootstrap/simple_form.pt.yml
@@ -57,3 +57,5 @@ pt:
         video_url: "Insira aqui o link do seu vídeo. Ele deve estar hospedado no Youtube ou no Vimeo. Se ainda não o tiver, tudo bem, você pode adicioná-lo depois. O vídeo é muito importante para o sucesso de sua campanha e obrigatório para projetos com metas de R$ 5.000 ou mais."
         about: '(Não se preocupe, você poderá mudar ela depois)'
         headline: '(Não se preocupe, você poderá mudar ela depois)'
+        online_days: 'Quantos dias você precisa para atingir sua meta? O tempo máximo é de 60 dias'
+        admin_online_days: '(Como administrador da Juntos, você pode inserir um valor maior que 60)'

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe Project, type: :model do
     describe "online_days acceptance validations" do
       it { is_expected.to     allow_value(1).for(:online_days) }
       it { is_expected.not_to allow_value(0).for(:online_days) }
-      it { is_expected.not_to allow_value(61).for(:online_days) }
     end
 
     describe "video_url acceptance validations" do

--- a/spec/services/project/create_spec.rb
+++ b/spec/services/project/create_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe Project::Create do
+  it_behaves_like 'when the validation of online_days needs to be done' do
+     let(:service) { :create }
+  end
+
+  describe ".process" do
+    let(:create_admin_service) { Project::Create.new(user, project.attributes) }
+    let(:service_process) { create_admin_service.process }
+    let(:project_with_61_online_days) { build(:project, online_days: 61) }
+
+    before(:each) do
+      service_process
+    end
+
+    context "when the user is a juntos' admin" do
+      let(:user) { create(:user, admin: true) }
+      let(:project) { project_with_61_online_days }
+
+      it "should create a project with any value greater than 0 for online_days" do
+        expect(create_admin_service.project.id).to_not be_nil
+      end
+    end
+
+    context "when the user is a common user" do
+      let(:user) { create(:user, admin: false) }
+
+      context "when online_days has a value greater than 0" do
+        let(:project) { build(:project, online_days: 59) }
+
+        it "must create the project" do
+          expect(create_admin_service.project.id).to_not be_nil
+        end
+      end
+
+      context "when online_days has a value greater than 61" do
+        let(:project) { project_with_61_online_days }
+
+        it "must not create the project" do
+          expect(create_admin_service.project.id).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/services/project/update_spec.rb
+++ b/spec/services/project/update_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe Project::Update do
+  it_behaves_like 'when the validation of online_days needs to be done' do
+     let(:service) { :update }
+  end
+
+  describe ".process" do
+    let(:project) { create(:project, online_days: 10) }
+    let(:params) { build(:project, online_days: 61).attributes }
+    let(:update_admin_service) { Project::Update.new(user, params, project) }
+    let(:service_process) { update_admin_service.process }
+    let(:project_with_61_online_days) { build(:project, online_days: 61) }
+
+    before(:each) do
+      service_process
+    end
+
+    describe "project.online_days" do
+      context "when the user is a juntos' admin" do
+        let(:user) { create(:user, admin: true) }
+
+        context "when is greater than 0" do
+          it "should return an updated project" do
+            expect(update_admin_service.project.online_days).to eq 61
+          end
+        end
+      end
+
+      context "when the user is a common user" do
+        let(:user) { create(:user, admin: false) }
+        let(:persisted_project) { Project.find(update_admin_service.project.id) }
+
+        context "when online_days has a value between 0 and 60" do
+          let(:params) { build(:project, online_days: 60).attributes }
+
+          it "should return an updated project" do
+            expect(persisted_project.online_days).to eq 60
+          end
+        end
+
+        context "when online_days has a value greater than 61" do
+          let(:params) { build(:project, online_days: 61).attributes }
+
+          it 'should not update the project' do
+            expect(persisted_project.online_days).to eq 10
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/project_admin_crud_services/crud_service.rb
+++ b/spec/support/shared_examples/project_admin_crud_services/crud_service.rb
@@ -1,0 +1,55 @@
+RSpec.shared_examples 'when the validation of online_days needs to be done' do
+  describe ".valid?" do
+    let(:juntos_admin) { create(:user, admin: true) }
+    let(:normal_user) { create(:user, admin: false) }
+
+    let(:crud_service) {
+      case service
+      when :create
+        Project::Create.new(user, project.attributes)
+      when :update
+        Project::Update.new(user, project.attributes, project)
+      end
+    }
+
+    context "when the online days value passed is greater than 60" do
+      let(:project) { build(:project, online_days: 61) }
+
+      context "when the current user is a juntos' admin" do
+        let(:user) { juntos_admin }
+
+        it "should be valid" do
+          expect(crud_service.valid?).to eq true
+        end
+      end
+
+      context "when the current user is a project owner or the project channel owner" do
+        let(:user) { normal_user }
+
+        it "should be invalid" do
+          expect(crud_service.valid?).to eq false
+        end
+      end
+    end
+
+    context "when the online days value passed is smaller than 60" do
+      let(:project) { build(:project, online_days: 59) }
+
+      context "when the current user is a juntos' admin" do
+        let(:user) { juntos_admin }
+
+        it "should be valid" do
+          expect(crud_service.valid?).to eq true
+        end
+      end
+
+      context "when the current user is a project owner or the project channel owner" do
+        let(:user) { normal_user }
+
+        it "should be valid" do
+          expect(crud_service.valid?).to eq true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Juntos' admins must have permission to create or update projects with values greater than 60 for the ```online_days``` attribute.