### PR TITLE
Changing the edit/destroy rewards buttons to the right color 

### DIFF
--- a/app/assets/stylesheets/_headers_from_future_juntos.scss
+++ b/app/assets/stylesheets/_headers_from_future_juntos.scss
@@ -199,14 +199,26 @@ $tablet-size: 768px;
   width: 86.4%;
 }
 .btn-edit {
-  border-color: #409bff !important;
-  background-color: #409bff !important;
+  border-color: $blue-note !important;
+  background-color: $blue-note !important;
   color: white !important;
   text-decoration: none !important;
+
+  &:hover {
+    border-color: $blue-facebook !important;
+    background-color: $blue-facebook !important;
+  }
 }
-.btn-edit:hover {
-  border-color: #409bff !important;
-  background-color: #2f8bed !important;
+.btn-delete {
+  border-color: $red !important;
+  background-color: $red !important;
+  color: white !important;
+  text-decoration: none !important;
+
+  &:hover {
+    border-color: $red-two !important;
+    background-color: $red-two !important;
+  }
 }
 .footer-news-icon {
   margin-top: 7px;

--- a/app/views/juntos_bootstrap/projects/_dashboard_reward.html.slim
+++ b/app/views/juntos_bootstrap/projects/_dashboard_reward.html.slim
@@ -24,7 +24,7 @@
                         .fontsize-base.fontweight-semibold= t('rewards.index.reward_title', minimum: reward.display_minimum).html_safe
                       .w-col.w-col-2
                         = link_to "javascript:void(0);", data: {target: ".edit_reward_content_#{reward.id}", parent: "#reward_#{reward.id}", path: edit_project_reward_path(@project, reward)}, class: 'show_reward_form' do
-                          .btn.btn-small.btn-terciary.fa.fa-lg.fa-edit.btn-no-border.reward-form-icons
+                          .btn.btn-small.btn-terciary.fa.fa-lg.fa-edit.btn-edit.btn-no-border.reward-form-icons
                     .fontsize-smaller.u-marginbottom-20.fontweight-semibold= pluralize(reward.contributions.with_state('confirmed').count(:all), t('contribution_singular'), t('contribution_plural'))
                     p.fontsize-small
                       br= reward.display_description

--- a/app/views/juntos_bootstrap/rewards/_form.html.slim
+++ b/app/views/juntos_bootstrap/rewards/_form.html.slim
@@ -40,4 +40,4 @@
             - if resource.persisted? && policy(resource).destroy?
               .w-col.w-col-1
                 = link_to [parent, resource], method: :delete, data: {confirm: t('.are_you_sure')} do
-                  .btn.btn-small.btn-terciary.fa.fa-lg.fa-trash.btn-no-border
+                  .btn.btn-small.btn-terciary.btn-delete.fa.fa-lg.fa-trash.btn-no-border

--- a/config/locales/catarse_bootstrap/simple_form.en.yml
+++ b/config/locales/catarse_bootstrap/simple_form.en.yml
@@ -39,6 +39,7 @@ en:
         description: 'Enter a description'
       subgoal:
         minimum_value: 'Enter a minimum value'
+        description: 'You need to enter a description for the subgoal'
     prompts:
       project:
         category: 'Choose a category'

--- a/config/locales/catarse_bootstrap/simple_form.pt.yml
+++ b/config/locales/catarse_bootstrap/simple_form.pt.yml
@@ -38,7 +38,8 @@ pt:
         minimum_value: 'Preencha o valor mínimo para a recompensa'
         description: 'Preencha o campo descrição'
       subgoal:
-        minimum_value: 'Preencha o valor mínimo para a recompensa'
+        minimum_value: 'Preencha o valor mínimo para a submeta'
+        description: 'Você precisa inserir uma descrição para a submeta'
     prompts:
       project:
         category: "Selecione uma categoria"


### PR DESCRIPTION
All juntos project's buttons have the yellow as main color. Following some UX purposes, the color of the edit and destroy buttons of the rewards form was changed to blue and red.

This PR contains a change that should has been made [here](https://github.com/juntos-com-vc/juntos.com.vc/pull/249)

Before:

<img width="637" alt="screen shot 2016-12-12 at 4 39 12 pm" src="https://cloud.githubusercontent.com/assets/7783787/21113820/c61b3200-c089-11e6-9f8c-7659a4d19549.png">
<img width="648" alt="screen shot 2016-12-12 at 4 40 10 pm" src="https://cloud.githubusercontent.com/assets/7783787/21113822/c88ab3da-c089-11e6-99ca-3b174b3f64d3.png">


After:
<img width="647" alt="screen shot 2016-12-12 at 4 39 31 pm" src="https://cloud.githubusercontent.com/assets/7783787/21113835/d15ee40e-c089-11e6-867b-89176b3dc14c.png">
<img width="637" alt="screen shot 2016-12-12 at 4 39 41 pm" src="https://cloud.githubusercontent.com/assets/7783787/21113837/d28b50c4-c089-11e6-9335-c1fe0b8795e7.png">
