### PR TITLE
Remove remind me for no expires at project

### DIFF
--- a/app/controllers/projects/reminders_controller.rb
+++ b/app/controllers/projects/reminders_controller.rb
@@ -2,11 +2,10 @@ class Projects::RemindersController < ApplicationController
   before_filter :authenticate_user!
 
   def create
-    unless current_user.has_valid_contribution_for_project?(params[:id]) && project.user_already_in_reminder?(current_user.id)
-      reminder_at = project.expires_at - 48.hours
-      ReminderProjectWorker.perform_at(reminder_at, current_user.id, project.id)
+    if Project::ReminderService.call(current_user, project)
+      flash[:notice] = t('projects.reminder.ok')
     end
-    flash[:notice] = t('projects.reminder.ok')
+
     redirect_to project_by_slug_path(project.permalink)
   end
 
@@ -16,7 +15,6 @@ class Projects::RemindersController < ApplicationController
 
     redirect_to project_by_slug_path(project.permalink)
   end
-
 
   protected
 

--- a/app/services/project/reminder_service.rb
+++ b/app/services/project/reminder_service.rb
@@ -1,0 +1,37 @@
+class Project::ReminderService
+  REMINDER_TIME_LEFT = 48.hours
+
+  def initialize(current_user, project)
+    @current_user = current_user
+    @project = project
+  end
+
+  def self.call(current_user, project)
+    new(current_user, project).call
+  end
+
+  def call
+    if accept_remind_me?
+      reminder_at = @project.expires_at - REMINDER_TIME_LEFT
+      ReminderProjectWorker.perform_at(reminder_at, @current_user.id, @project.id)
+    end
+  end
+
+  private
+
+  def accept_remind_me?
+    user_has_invalid_contribution? && user_not_in_reminder? && project_has_expires_at?
+  end
+
+  def user_has_invalid_contribution?
+    !@current_user.has_valid_contribution_for_project?(@project.id)
+  end
+
+  def user_not_in_reminder?
+    !@project.user_already_in_reminder?(@current_user.id)
+  end
+
+  def project_has_expires_at?
+    !@project.expires_at.nil?
+  end
+end

--- a/app/views/juntos_bootstrap/projects/_project_about.html.slim
+++ b/app/views/juntos_bootstrap/projects/_project_about.html.slim
@@ -6,15 +6,10 @@
     #facebook_share.img-share = render_facebook_like title: @project.name, href: project_by_slug_url(@project.permalink, locale: I18n.locale)
   .w-col.w-col-3
     #twitter_share.img-share = render_twitter(url: project_by_slug_url(permalink: @project.permalink), title: @project.name)
-  .w-col.w-col-3
+  / .w-col.w-col-3
     /= link_to t('.embed'), '#embed', id: 'embed_link', class: 'link-hidden fontsize-small fontcolor-secondary'
-  .w-col.w-col-3
-    - if user_signed_in? && @project.user_already_in_reminder?(current_user.id)
-      .fontsize-small
-        = link_to t('.deactive_btn'), reminder_project_path(@project), class: 'fa fa-clock-o link-hidden-success u-right', method: :delete
-    - else
-      .fontsize-small
-        = link_to t('.active_btn'), reminder_project_path(@project), class: 'fa fa-clock-o link-hidden u-right fontcolor-secondary'
+  .w-col.w-col-6
+    = render 'project_remind_me'
 
 
 - unless @project.permalink == 'toddynho'

--- a/app/views/juntos_bootstrap/projects/_project_remind_me.html.slim
+++ b/app/views/juntos_bootstrap/projects/_project_remind_me.html.slim
@@ -1,0 +1,9 @@
+- if @project.expires_at.present?
+  - if user_signed_in? && @project.user_already_in_reminder?(current_user.id)
+    .fontsize-small
+      = link_to t('projects.project_about.deactive_btn'), reminder_project_path(@project), class: 'fa fa-clock-o link-hidden-success u-right', method: :delete
+  - else
+    .fontsize-small
+      = link_to t('projects.project_about.active_btn'), reminder_project_path(@project), class: 'fa fa-clock-o link-hidden u-right fontcolor-secondary'
+- else
+  = t('projects.project_about.unavailable_reminder')

--- a/app/workers/reminder_project_worker.rb
+++ b/app/workers/reminder_project_worker.rb
@@ -6,8 +6,6 @@ class ReminderProjectWorker
     user = User.find user_id
     project = Project.find project_id
 
-    unless user.has_valid_contribution_for_project?(project_id)
-      project.notify_once(:reminder, user, project)
-    end
+    project.notify_once(:reminder, user, project)
   end
 end

--- a/config/locales/catarse_bootstrap/views/projects/show.en.yml
+++ b/config/locales/catarse_bootstrap/views/projects/show.en.yml
@@ -117,6 +117,7 @@ en:
       embed_title: 'Embed it on your site'
       active_btn: ' Remember me'
       deactive_btn: ' Reminder active'
+      unavailable_reminder: 'The project must be online for to be reminded'
       contributions: 'donors'
       goal: achieved of %{total}
     show:

--- a/config/locales/catarse_bootstrap/views/projects/show.pt.yml
+++ b/config/locales/catarse_bootstrap/views/projects/show.pt.yml
@@ -121,6 +121,7 @@ pt:
       embed_title: Incorpore este projeto no seu site
       active_btn: ' Lembrar-me'
       deactive_btn: ' Lembrete ativo'
+      unavailable_reminder: 'O projeto precisa estar online para adicionar lembrete'
       contributions: doadores
       goal: atingidos de %{total}
     show:

--- a/spec/controllers/projects/reminders_controller_spec.rb
+++ b/spec/controllers/projects/reminders_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Projects::RemindersController, type: :controller do
+
+  let(:user)    { create(:user) }
+  let(:project) { create(:project) }
+
+  before { sign_in user }
+
+  describe '#POST' do
+    before { allow(ReminderProjectWorker).to receive(:perform_at) }
+
+    it 'redirects to project_by_slug_path' do
+      post(:create, id: project.id)
+
+      expect(response).to redirect_to project_by_slug_path(project.permalink)
+    end
+
+    context 'when the user has invalid contribution for the project' do
+      before { allow(Project::ReminderService).to receive(:call).and_return(true) }
+
+      it 'should not create a reminder' do
+        post(:create, id: project.id)
+
+        expect(flash[:notice]).to eq(I18n.t('projects.reminder.ok'))
+      end
+    end
+  end
+end

--- a/spec/services/project/reminder_service_spec.rb
+++ b/spec/services/project/reminder_service_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Project::ReminderService do
+  let(:user)        { create(:user) }
+  let(:project)     { create(:project, online_date: Time.current, online_days: 10) }
+  let(:reminder_at) { project.expires_at - 48.hours }
+
+  before { allow(ReminderProjectWorker).to receive(:perform_at) }
+
+  describe '.call' do
+    context 'when the user is not in remind me' do
+      before { Project::ReminderService.call(user, project) }
+
+      it 'should create a reminder' do
+        expect(ReminderProjectWorker).to have_received(:perform_at).
+          with(reminder_at, user.id, project.id)
+      end
+    end
+
+    context 'when the user has invalid contribution for the project' do
+      before do
+        create(:contribution, :confirmed, project: project, user: user)
+
+        Project::ReminderService.call(user, project)
+      end
+
+      it 'should not create a reminder' do
+        expect(ReminderProjectWorker).not_to have_received(:perform_at)
+      end
+    end
+
+    context 'when the user is already in remind me' do
+      before do
+        allow(project).to receive(:user_already_in_reminder?).and_return(true)
+
+        Project::ReminderService.call(user, project)
+      end
+
+      it 'should not create a reminder' do
+        expect(ReminderProjectWorker).not_to have_received(:perform_at)
+      end
+    end
+
+    context 'when project does not have expires_at' do
+      let(:project) { create(:project, online_date: nil) }
+      before        { Project::ReminderService.call(user, project) }
+
+      it 'should not create a reminder' do
+        expect(ReminderProjectWorker).not_to have_received(:perform_at)
+      end
+    end
+  end
+end


### PR DESCRIPTION
It was showing `remind me` link even when the `project.expires_at` was `nil`. It was causing error, because the reminders_controller did not check it and just did `project.expires_at - 48.hours`.

Now the `remind me` link is not even shown if `project.expires_at` is `nil`.