### PR TITLE
Creating service which will update juntos subscription status 

### DIFF
--- a/app/services/recurring_contribution/subscriptions/update_status.rb
+++ b/app/services/recurring_contribution/subscriptions/update_status.rb
@@ -1,0 +1,15 @@
+class RecurringContribution::Subscriptions::UpdateStatus
+  def initialize(subscription_code, current_status)
+    @juntos_subscription = Subscription.find_by(subscription_code: subscription_code)
+    @current_status = current_status
+  end
+
+  def self.process(subscription_code, current_status)
+    new(subscription_code, current_status).process
+  end
+
+  def process
+    @juntos_subscription.update(status: @current_status)
+    @juntos_subscription
+  end
+end

--- a/spec/services/recurring_contribution/subscriptions/update_status_spec.rb
+++ b/spec/services/recurring_contribution/subscriptions/update_status_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe RecurringContribution::Subscriptions::UpdateStatus do
+  include RecurringContributionsHelper
+
+  describe ".process" do
+    let(:pagarme_subscription) { build_subscription_mock('credit_card') }
+    let!(:juntos_subscription) { create(:subscription, subscription_code: pagarme_subscription.id, status: 'pending_payment') }
+    let(:update_subscription_service) { described_class.process(pagarme_subscription.id, current_status) }
+
+    context "when the current status is permitted" do
+      let(:current_status) { 'paid' }
+
+      it "updates the Subscription status" do
+        expect{ update_subscription_service }.to change { juntos_subscription.reload.status }.from('pending_payment').to('paid')
+      end
+    end
+
+    context "when an invalid status is passed as param" do
+      let(:current_status) { 'invalid status' }
+
+      it "returns an invalid subscription instance" do
+        expect(update_subscription_service).to be_invalid
+      end
+    end
+  end
+end


### PR DESCRIPTION
This service will be responsible for update juntos' subscriptions statuses when the PagarMe's API sinalize(via POST request) some change in the subscription status.