### PR TITLE
fix the way that the project params is sent to update service

### DIFF
--- a/app/controllers/projects/posts_controller.rb
+++ b/app/controllers/projects/posts_controller.rb
@@ -23,7 +23,7 @@ class Projects::PostsController < ApplicationController
 
   def destroy
     authorize resource
-    destroy!{ return index }
+    destroy!{ project_by_slug_path(permalink: resource.project.permalink, anchor: 'posts') }
   end
 
   def collection

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -107,7 +107,7 @@ class ProjectsController < ApplicationController
 
   def update
     authorize resource
-    @project_update = Project::Update.new(current_user, params[:project], resource)
+    @project_update = Project::Update.new(current_user, project_params, resource)
 
     if @project_update.process
       @project = @project_update.project
@@ -182,6 +182,10 @@ class ProjectsController < ApplicationController
       p[:project][:posts_attributes]['0'].merge!({user: current_user})
     end
     p
+  end
+
+  def project_params
+    permitted_params[:project]
   end
 
   def resource

--- a/spec/controllers/projects/posts_controller_spec.rb
+++ b/spec/controllers/projects/posts_controller_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe Projects::PostsController, type: :controller do
 
     context 'When user is admin' do
       let(:current_user) { FactoryGirl.create(:user, admin: true) }
-      its(:status) { should == 200}
+      its(:status) { should == 302 }
     end
 
     context 'When user is project_owner' do
       let(:current_user) { project_post.project.user }
-      its(:status) { should == 200}
+      its(:status) { should == 302 }
     end
   end
 

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -293,27 +293,27 @@ RSpec.describe ProjectsController, type: :controller do
       end
 
       context "when the request is a PUT" do
-        let(:project) { build(:project, online_days: 61) }
+        context 'and it updates the online_days' do
+          let(:project) { create(:project, :draft, online_days: 15, user: user) }
 
-        before(:each) do
-          put :update, id: project.id, project: { online_days: 61 }, locale: :pt
-        end
-
-        context "when the current_user is a juntos' admin" do
-          let(:user) { create(:user, admin: true) }
-          let(:project) { create(:project, online_days: 15, user: user) }
-
-          it "should not show any error message" do
-            expect(flash[:alert]).to be_nil
+          before(:each) do
+            put :update, id: project.id, project: { online_days: 61 }, locale: :pt
           end
-        end
 
-        context "when the current_user is a normal user" do
-          let(:user) { create(:user, admin: false) }
-          let(:project) { create(:project, online_days: 15, user: user) }
+          context "when the current_user is a juntos' admin" do
+            let(:user) { create(:user, admin: true) }
 
-          it 'should return a flash error message for the online_days field' do
-            expect(flash[:alert]).to match online_days_error_message
+            it "should not show any error message" do
+              expect(flash[:alert]).to be_nil
+            end
+          end
+
+          context "when the current_user is a normal user" do
+            let(:user) { create(:user, admin: false) }
+
+            it 'should return a flash error message for the online_days field' do
+              expect(flash[:alert]).to match online_days_error_message
+            end
           end
         end
       end


### PR DESCRIPTION
**Problem:**
When creating a project post, there is no `current_user` sending into params, what is causing error because the post belongs to user.
**Solution:**
Use an existing protected method that merges the project params to current user.