### PR TITLE
Fix inconsistence on display project contributions

### DIFF
--- a/app/views/juntos_bootstrap/projects/_project_header.html.slim
+++ b/app/views/juntos_bootstrap/projects/_project_header.html.slim
@@ -81,7 +81,7 @@
               - if @project.permalink == 'aumigo'
                 | 4618
               - else
-                = @project.contributions.available_to_count.count
+                = @project.total_contributions
             li.u-marginleft-20.fontsize-smallest
               = t('projects.project_about.contributions')
         - unless @channel && @channel.recurring?


### PR DESCRIPTION
The project contributions count is calculated in two different places, where in one of them only the `status: 'confirmed', 'requested_refund'` matter, while in the other one the `status: 'confirmed', 'requested_refund', 'refunded'` matter.

This let the project contributions count for both being calculated in the same place.