### PR TITLE
Update how many days a waiting confirmation contribution should be canceled

### DIFF
--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -71,7 +71,7 @@ class Contribution < ActiveRecord::Base
     with_state('confirmed').where("contributions.payment_method in ('PayPal', 'Pagarme') OR contributions.payment_choice = 'CartaoDeCredito'")
   }
   scope :partner_indications, -> { where(partner_indication: true) }
-  scope :can_cancel, -> { with_state('waiting_confirmation').where('created_at < ?', 8.weekdays_ago.to_date) }
+  scope :can_cancel, -> { with_state('waiting_confirmation').where('created_at < ?', 5.weekdays_ago.to_date) }
   scope :with_cause, ->(cause_id) {
     joins(:project).where(projects: { category_id: cause_id })
   }

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -31,7 +31,7 @@ task :move_pending_contributions_to_trash => [:environment] do
   Contribution.where("state in('pending') and created_at + interval '15 days' < current_timestamp").update_all({state: 'deleted'})
 end
 
-desc "Cancel all waiting_confirmation contributions that is passed 4 weekdays"
+desc "Cancel all waiting_confirmation contributions that has passed 5 weekdays"
 task :cancel_expired_waiting_confirmation_contributions => :environment do
   Contribution.can_cancel.update_all(state: 'canceled')
 end

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Contribution, type: :model do
 
     context "when contribution is in time to wait the confirmation" do
       before do
-        create(:contribution, :waiting_confirmation, created_at: 8.weekdays_ago)
+        create(:contribution, :waiting_confirmation, created_at: 5.weekdays_ago)
         create(:contribution, :waiting_confirmation, created_at: 1.weekdays_ago)
       end
 
@@ -136,13 +136,12 @@ RSpec.describe Contribution, type: :model do
 
     context "when we have contributions that are ahead of confirmation time" do
       before do
-        create(:contribution, :waiting_confirmation, :slip_payment, created_at: 8.weekdays_ago)
-        create(:contribution, :waiting_confirmation, :slip_payment, created_at: 7.weekdays_ago)
-        create(:contribution, :waiting_confirmation, :slip_payment, created_at: 1.weekdays_ago)
-        create(:contribution, :waiting_confirmation, created_at: 8.weekdays_ago)
+        create(:contribution, :waiting_confirmation, :slip_payment, created_at: 5.weekdays_ago)
+        create(:contribution, :waiting_confirmation, :slip_payment, created_at: 3.weekdays_ago)
+        create(:contribution, :waiting_confirmation, created_at: 4.weekdays_ago)
         create(:contribution, :waiting_confirmation, created_at: 5.weekdays_ago)
       end
-      let!(:old_contribution) { create(:contribution, :waiting_confirmation, :slip_payment, created_at: 9.weekdays_ago) }
+      let!(:old_contribution) { create(:contribution, :waiting_confirmation, :slip_payment, created_at: 6.weekdays_ago) }
 
       it { is_expected.to contain_exactly(old_contribution) }
     end


### PR DESCRIPTION
When a contribution has the state `waiting_confirmation` for 5 or more days, it should be canceled.