### PR TITLE
Creating RecurringContribution::Subscriptions::CreateJuntos service

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,15 +1,17 @@
 class Subscription < ActiveRecord::Base
   extend Enumerize
 
-  validates_presence_of :status, :payment_method,
+  validates_presence_of :status, :payment_method, :charging_day,
                         :plan_id, :user_id, :project_id
 
   validates_inclusion_of :payment_method, in: 'permitted_payment_methods',
                                           unless: 'plan.nil?'
 
+  validates_numericality_of :charging_day, less_than_or_equal_to: 28, greater_than: 0
+
   enumerize :payment_method, in: { credit_card: 0, bank_billet: 1 }
 
-  enumerize :status, in: { paid: 0, pending_payment: 1, unpaid: 2, canceled: 3 }
+  enumerize :status, in: { paid: 0, pending_payment: 1, unpaid: 2, canceled: 3, waiting_for_charging_day: 4 }
 
   has_many   :transactions
   belongs_to :user

--- a/app/services/pagarme/api.rb
+++ b/app/services/pagarme/api.rb
@@ -29,6 +29,14 @@ class Pagarme::API
       raise_connection_error
     end
 
+    def create_credit_card(attributes)
+      PagarMe::Card.create(attributes)
+    rescue PagarMe::ConnectionError
+      raise_connection_error
+    rescue PagarMe::ValidationError => e
+      raise InvalidAttributeError, e.message
+    end
+
     private
 
     def raise_connection_error

--- a/app/services/recurring_contribution/subscriptions/create_juntos.rb
+++ b/app/services/recurring_contribution/subscriptions/create_juntos.rb
@@ -1,0 +1,43 @@
+class RecurringContribution::Subscriptions::CreateJuntos
+  def initialize(project, plan, user, payment_method, charging_day, credit_card_attributes)
+    @project = project
+    @plan = plan
+    @user = user
+    @payment_method = payment_method
+    @charging_day = charging_day
+    @credit_card_attributes = credit_card_attributes
+  end
+
+  def self.process(project:, plan:, user:, payment_method:, charging_day:, credit_card_hash: {})
+    new(project, plan, user, payment_method, charging_day, credit_card_hash).process
+  end
+
+  def process
+    create_credit_card_on_pagarme if paid_with_credit_card?
+    create_subscription
+  end
+
+  private
+  attr_reader   :project, :payment_method, :plan, :user, :charging_day, :credit_card_attributes
+
+  def create_subscription
+    Subscription.create(
+      status:            :waiting_for_charging_day,
+      payment_method:    payment_method,
+      plan:              plan,
+      project:           project,
+      user:              user,
+      credit_card_key:   @credit_card_key,
+      charging_day:      charging_day
+    )
+  end
+
+  def create_credit_card_on_pagarme
+    pagarme_response = Pagarme::API.create_credit_card(credit_card_attributes)
+    @credit_card_key = pagarme_response.id
+  end
+
+  def paid_with_credit_card?
+    payment_method == 'credit_card'
+  end
+end

--- a/db/migrate/20161223191639_add_charging_day_to_subscriptions.rb
+++ b/db/migrate/20161223191639_add_charging_day_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddChargingDayToSubscriptions < ActiveRecord::Migration
+  def change
+    add_column :subscriptions, :charging_day, :integer
+  end
+end

--- a/db/migrate/20161223194522_add_credit_card_key_to_subscriptions.rb
+++ b/db/migrate/20161223194522_add_credit_card_key_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddCreditCardKeyToSubscriptions < ActiveRecord::Migration
+  def change
+    add_column :subscriptions, :credit_card_key, :string
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -297,6 +297,7 @@ FactoryGirl.define do
     f.subscription_code { rand(1..100) }
     f.payment_method :credit_card
     f.status :paid
+    f.charging_day 5
     f.association :project, factory: :project
     f.association :plan, factory: :plan
     f.association :user, factory: :user

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -2,34 +2,38 @@ require 'rails_helper'
 
 RSpec.describe Subscription, type: :model do
 
-  describe 'associations' do
+  describe "associations" do
     it{ is_expected.to belong_to :user }
     it{ is_expected.to belong_to :project }
     it{ is_expected.to belong_to :plan }
   end
 
-  describe 'validations' do
+  describe "validations" do
     let(:plan) { create(:plan, :with_credit_card) }
     let(:unpermitted_payment_subscription) { build(:subscription, :bank_billet_payment, plan: plan) }
     let(:permitted_payment_subscription) { build(:subscription, :credit_card_payment, plan: plan) }
 
     it { is_expected.to validate_presence_of(:status) }
+    it { is_expected.to validate_presence_of(:charging_day) }
     it { is_expected.to validate_presence_of(:payment_method) }
     it { is_expected.to validate_presence_of(:plan_id) }
     it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.to validate_presence_of(:project_id) }
 
+    it { is_expected.not_to allow_value(0).for(:charging_day) }
+    it { is_expected.not_to allow_value(29).for(:charging_day) }
+
     it { is_expected.to enumerize(:payment_method).in(:credit_card, :bank_billet) }
-    it { is_expected.to enumerize(:status).in(:paid, :pending_payment, :unpaid, :canceled) }
+    it { is_expected.to enumerize(:status).in(:paid, :pending_payment, :unpaid, :canceled, :waiting_for_charging_day) }
 
     context "when the subscription is made with a plan's unpermitted payment type" do
-      it 'should be invalid' do
+      it "should be invalid" do
         expect(unpermitted_payment_subscription).to be_invalid
       end
     end
 
-    context 'when the payment_method is permitted by the plan' do
-      it 'should be valid' do
+    context "when the payment_method is permitted by the plan" do
+      it "should be valid" do
         expect(permitted_payment_subscription).to be_valid
       end
     end

--- a/spec/services/recurring_contribution/subscriptions/create_juntos_spec.rb
+++ b/spec/services/recurring_contribution/subscriptions/create_juntos_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe RecurringContribution::Subscriptions::CreateJuntos do
+  describe ".process" do
+    let(:project)     { create(:project) }
+    let(:plan)        { create(:plan) }
+
+    context "when all parameters sent are valid" do
+      subject do
+        RecurringContribution::Subscriptions::CreateJuntos.process(
+          project:          project,
+          plan:             plan,
+          user:             project.user,
+          payment_method:   'bank_billet',
+          charging_day:     5
+        )
+      end
+
+      context "payment_method" do
+        subject do
+          RecurringContribution::Subscriptions::CreateJuntos.process(
+            project:          project,
+            plan:             plan,
+            user:             project.user,
+            payment_method:   payment_method,
+            charging_day:     5,
+            credit_card_hash: credit_card_attributes
+          )
+        end
+
+        context "when credit card" do
+          let(:payment_method) { 'credit_card' }
+          let(:credit_card_attributes) { build(:credit_card) }
+          let(:pagarme_response_for_card_creation) { double('Card', id: 'card_ci6y37h16wrxsmzyi') }
+
+          it "should create a PagarMe::Card" do
+            allow(Pagarme::API).to receive(:create_credit_card)
+              .with(credit_card_attributes).and_return(pagarme_response_for_card_creation)
+
+            expect(subject.credit_card_key).to eq 'card_ci6y37h16wrxsmzyi'
+          end
+        end
+
+        context "when bank billet" do
+          let(:payment_method) { 'bank_billet' }
+          let(:credit_card_attributes) { Hash.new }
+
+          it "should create a subscription with a nil credit_card_key" do
+            expect(subject.credit_card_key).to be_nil
+          end
+        end
+      end
+
+      it "should return a subscription" do
+        expect(subject)
+          .to have_attributes(status: :waiting_for_charging_day, plan_id: plan.id, credit_card_key: nil)
+      end
+
+      it "should create a subscription" do
+        expect(subject.persisted?).to eq true
+      end
+    end
+
+    context "when invalid parameters are sent" do
+      subject do
+        RecurringContribution::Subscriptions::CreateJuntos.process(
+          project:          project,
+          plan:             plan,
+          user:             project.user,
+          payment_method:   'bank_billet',
+          charging_day:     29
+        )
+      end
+
+      it "returns an invalid subscription instance" do
+        expect(subject).to be_invalid
+      end
+    end
+
+    context "when a problem occurs with PagarMe's API on credit_card creation" do
+      let(:credit_card_attributes) { build(:credit_card) }
+      subject do
+        RecurringContribution::Subscriptions::CreateJuntos.process(
+          project:          project,
+          plan:             plan,
+          user:             project.user,
+          payment_method:   'credit_card',
+          charging_day:     5,
+          credit_card_hash: credit_card_attributes
+        )
+      end
+
+      context "when connection is lost" do
+        it "raises a Pagarme::API::ConnectionError error" do
+          allow(Pagarme::API).to receive(:create_credit_card)
+            .with(credit_card_attributes).and_raise(Pagarme::API::ConnectionError)
+
+          expect { subject }
+            .to raise_error Pagarme::API::ConnectionError
+        end
+      end
+
+      context "when invalid credit card parameters are sent" do
+        it "raises a Pagarme::API::InvalidAttributeError error" do
+          allow(Pagarme::API).to receive(:create_credit_card)
+            .with(credit_card_attributes).and_raise(Pagarme::API::InvalidAttributeError)
+
+          expect { subject }
+            .to raise_error Pagarme::API::InvalidAttributeError
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This service will create a subscription on juntos' database, scheduling the pagarme's charging day. All subscriptions which have the `waiting_for_charging_day` status will be created on pagarme if the current day was equal to the `charging_day` attribute.

Two more attributes were added on Subscription's model: `charging_day` and `credit_card_key`. The `credit_card_key` is a reference to the CreditCard created on Pagarme when a subscription paid with credit card is made. The `charging day` refer to the month's day which the user will be charged by pagarme.