### PR TITLE
Creating the charging subscriptions rake task

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,6 +1,4 @@
 class Subscription < ActiveRecord::Base
-  extend Enumerize
-
   validates_presence_of :status, :payment_method, :charging_day,
                         :plan_id, :user_id, :project_id
 
@@ -9,14 +7,16 @@ class Subscription < ActiveRecord::Base
 
   validates_numericality_of :charging_day, less_than_or_equal_to: 28, greater_than: 0
 
-  enumerize :payment_method, in: { credit_card: 0, bank_billet: 1 }
+  enum payment_method: [ :credit_card, :bank_billet ]
 
-  enumerize :status, in: { paid: 0, pending_payment: 1, unpaid: 2, canceled: 3, waiting_for_charging_day: 4 }
+  enum status: [ :pending_payment, :paid, :unpaid, :canceled, :waiting_for_charging_day ]
 
   has_many   :transactions
   belongs_to :user
   belongs_to :project
   belongs_to :plan
+
+  scope :charging_day_reached, -> { waiting_for_charging_day.where(charging_day: DateTime.current.day) }
 
   private
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,22 +1,12 @@
 class Transaction < ActiveRecord::Base
-  extend Enumerize
-
   validates_presence_of :transaction_code, :status, :amount,
                         :payment_method, :subscription_id
 
   belongs_to :subscription
   has_one    :project, through: :subscription
 
-  enumerize :status, in: {
-                           processing:      0,
-                           authorized:      1,
-                           paid:            2,
-                           refunded:        3,
-                           waiting_payment: 4,
-                           pending_payment: 5,
-                           refused:         6
-                         }
+  enum status: [ :pending_payment, :processing, :authorized, :paid, :refunded, :waiting_payment, :refused ]
 
-   enumerize :payment_method, in: { credit_card: 0, bank_billet: 1 }
+  enum payment_method: [ :credit_card, :bank_billet ]
 
 end

--- a/app/workers/recurring_contribution/charging_subscription_worker.rb
+++ b/app/workers/recurring_contribution/charging_subscription_worker.rb
@@ -1,0 +1,28 @@
+class RecurringContribution::ChargingSubscriptionWorker
+  include Sidekiq::Worker
+  sidekiq_options retry: 2
+
+  def perform
+    Subscription.charging_day_reached.each do |juntos_subscription|
+      process_subscription_creation(juntos_subscription)
+    end
+  end
+
+  private
+
+  def process_subscription_creation(juntos_subscription)
+    RecurringContribution::Subscriptions::Create.process(juntos_subscription)
+  rescue RecurringContribution::Subscriptions::UpdateJuntos::InvalidPagarmeSubscription
+    log_error_message(juntos_subscription, "An invalid subscription was sent by PagarMe")
+  rescue Pagarme::API::ResourceNotFound
+    log_error_message(juntos_subscription, "The subscription's plan does not exist on PagarMe's database")
+  rescue Pagarme::API::InvalidAttributeError => e
+    log_error_message(juntos_subscription, "Invalid attributes sent: #{e}")
+  rescue Pagarme::API::ConnectionError
+    log_error_message(juntos_subscription, "A problem occurs on connection with PagarMe's API")
+  end
+
+  def log_error_message(subscription, message)
+    Rails.logger.error "[RecurringContribution::ChargingSubscriptionWorker] ID: #{subscription.id} DESCRIPTION: #{message}"
+  end
+end

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -134,3 +134,10 @@ task :deliver_credits_more_than_10, [:percent] => :environment do |t, args|
     user.notify(:credits_warning_more_group)
   end
 end
+
+namespace :recurring_contribution do
+  desc "Create pagarme's subscriptions scheduled for the current day"
+  task create_scheduled_pagarme_subscriptions: :environment do
+    RecurringContribution::ChargingSubscriptionWorker.perform_async
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -309,6 +309,14 @@ FactoryGirl.define do
     trait :credit_card_payment do
       payment_method :credit_card
     end
+
+    trait :waiting_for_charging_day do
+      status :waiting_for_charging_day
+    end
+
+    trait :unpaid do
+      status :unpaid
+    end
   end
 
   factory :transaction do |f|

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -23,8 +23,17 @@ RSpec.describe Subscription, type: :model do
     it { is_expected.not_to allow_value(0).for(:charging_day) }
     it { is_expected.not_to allow_value(29).for(:charging_day) }
 
-    it { is_expected.to enumerize(:payment_method).in(:credit_card, :bank_billet) }
-    it { is_expected.to enumerize(:status).in(:paid, :pending_payment, :unpaid, :canceled, :waiting_for_charging_day) }
+    describe "enumerators" do
+      it "should define an enum for payment_method" do
+        is_expected.to define_enum_for(:payment_method)
+          .with([ :credit_card, :bank_billet ])
+      end
+
+      it "should define an enum for status" do
+        is_expected.to define_enum_for(:status)
+          .with([ :pending_payment, :paid, :unpaid, :canceled, :waiting_for_charging_day ])
+      end
+    end
 
     context "when the subscription is made with a plan's unpermitted payment type" do
       it "should be invalid" do
@@ -35,6 +44,25 @@ RSpec.describe Subscription, type: :model do
     context "when the payment_method is permitted by the plan" do
       it "should be valid" do
         expect(permitted_payment_subscription).to be_valid
+      end
+    end
+  end
+
+  describe ".charging_day_reached" do
+    let(:charging_date) { DateTime.current.change(day: 15) }
+    let!(:subscriptions_scheduled_for_charging_date) do
+      create_list(:subscription, 4, :waiting_for_charging_day, charging_day: 15)
+    end
+
+    before do
+      create_list(:subscription, 5, :unpaid, charging_day: 15)
+      create_list(:subscription, 3, :waiting_for_charging_day, charging_day: 13)
+      create_list(:subscription, 3, :waiting_for_charging_day, charging_day: 18)
+    end
+
+    it "returns only waiting_for_charging_day subscriptions with the charging_day equals to the current day" do
+      Timecop.freeze(charging_date) do
+        expect(Subscription.charging_day_reached).to match_array subscriptions_scheduled_for_charging_date
       end
     end
   end

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -8,10 +8,17 @@ RSpec.describe Transaction, type: :model do
     it { is_expected.to validate_presence_of(:payment_method) }
     it { is_expected.to validate_presence_of(:subscription_id) }
 
-    it { is_expected.to enumerize(:payment_method).in(:credit_card, :bank_billet) }
-    it { is_expected.to enumerize(:status).in(:processing, :authorized, :paid,
-                                              :refunded, :waiting_payment,
-                                              :pending_payment, :refused) }
+    describe "enumerators" do
+      it "should define an enum for payment_method" do
+        is_expected.to define_enum_for(:payment_method)
+          .with([ :credit_card, :bank_billet ])
+      end
+
+      it "should define an enum for status" do
+        is_expected.to define_enum_for(:status)
+          .with([ :pending_payment, :processing, :authorized, :paid, :refunded, :waiting_payment, :refused ])
+      end
+    end
   end
 
   describe 'associations' do

--- a/spec/services/recurring_contribution/subscriptions/create_juntos_spec.rb
+++ b/spec/services/recurring_contribution/subscriptions/create_juntos_spec.rb
@@ -51,9 +51,8 @@ RSpec.describe RecurringContribution::Subscriptions::CreateJuntos do
         end
       end
 
-      it "should return a subscription" do
-        expect(subject)
-          .to have_attributes(status: :waiting_for_charging_day, plan_id: plan.id, credit_card_key: nil)
+      it "should return a subscription with a 'waiting_for_charging_day' status" do
+        expect(subject.status).to match 'waiting_for_charging_day'
       end
 
       it "should create a subscription" do

--- a/spec/services/recurring_contribution/subscriptions/update_juntos_spec.rb
+++ b/spec/services/recurring_contribution/subscriptions/update_juntos_spec.rb
@@ -44,13 +44,6 @@ RSpec.describe RecurringContribution::Subscriptions::UpdateJuntos do
             .to raise_error(RecurringContribution::Subscriptions::UpdateJuntos::InvalidPagarmeSubscription)
         end
       end
-
-      context "when the pagarme's subscription status is invalid" do
-        it "should return an invalid subscription instance" do
-          allow(pagarme_subscription).to receive(:status).and_return(:invalid_status)
-          expect(service_response).to be_invalid
-        end
-      end
     end
   end
 end

--- a/spec/support/shared_examples/recurring_contributions/update_status_services.rb
+++ b/spec/support/shared_examples/recurring_contributions/update_status_services.rb
@@ -18,17 +18,6 @@ RSpec.shared_examples "update status service" do
             .from('pending_payment').to('paid')
         end
       end
-
-      context "when an invalid status is passed as param" do
-        let(:current_status) { 'invalid status' }
-        let(:params) { { id: pagarme_resource.id, current_status: current_status } }
-        let(:request) { double('Request', params: params) }
-        let(:update_service) { described_class.process(request, juntos_resource) }
-
-        it "returns an invalid resource instance" do
-          expect(update_service).to be_invalid
-        end
-      end
     end
 
     context "when the request is made by an unauthorized resource" do

--- a/spec/tasks/recurring_contribution/create_scheduled_pagarme_subscriptions_rake_spec.rb
+++ b/spec/tasks/recurring_contribution/create_scheduled_pagarme_subscriptions_rake_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe "Subscriptions" do
+  before do
+    Rake.application.rake_require 'tasks/cron'
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "recurring_contribution:create_scheduled_pagarme_subscriptions" do
+    let(:run_rake_task) do
+      Rake::Task['recurring_contribution:create_scheduled_pagarme_subscriptions'].reenable
+      Rake.application.invoke_task 'recurring_contribution:create_scheduled_pagarme_subscriptions'
+    end
+
+    it "calls the RecurringContribution::ChargingSubscriptionWorker" do
+      expect(RecurringContribution::ChargingSubscriptionWorker)
+        .to receive(:perform_async).at_most(:twice)
+      run_rake_task
+    end
+  end
+end

--- a/spec/workers/recurring_contribution/charging_subscription_worker_spec.rb
+++ b/spec/workers/recurring_contribution/charging_subscription_worker_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+require 'sidekiq/testing'
+Sidekiq::Testing.fake!
+
+RSpec.describe RecurringContribution::ChargingSubscriptionWorker do
+  describe "#perform" do
+    let(:current_date) { DateTime.current.change(day: 15) }
+
+    context "when there is one or more juntos' subscription with the waiting_for_charging_day status" do
+      context "when the subscription charging_day is equal to the current day" do
+        before do
+          create_list(:subscription, 5, :waiting_for_charging_day, charging_day: 13)
+          create_list(:subscription, 5, :waiting_for_charging_day, charging_day: 15)
+          create_list(:subscription, 2, :waiting_for_charging_day, charging_day: 18)
+          create_list(:subscription, 3, :unpaid)
+        end
+
+        it "creates the pagarme's subscriptions for each juntos' subscription found" do
+          Timecop.freeze(current_date) do
+            expect(RecurringContribution::Subscriptions::Create)
+              .to receive(:process).exactly(5).times
+
+            Sidekiq::Testing.inline! do
+              RecurringContribution::ChargingSubscriptionWorker.perform_async
+            end
+          end
+        end
+      end
+    end
+
+    context "when there is no juntos subscriptions with the waiting_for_charging_day status" do
+      before do
+        create_list(:subscription, 5, :waiting_for_charging_day, charging_day: 13)
+        create_list(:subscription, 2, :waiting_for_charging_day, charging_day: 18)
+        create_list(:subscription, 3, :unpaid)
+      end
+
+      it "does not create pagarme subscriptions" do
+        Timecop.freeze(current_date) do
+          expect(RecurringContribution::Subscriptions::Create)
+            .to_not receive(:process)
+
+          Sidekiq::Testing.inline! do
+            RecurringContribution::ChargingSubscriptionWorker.perform_async
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This rake task calls the RecurringContribution::ChargingSubscriptionWorker which will search for all juntos subscriptions with the `waiting_for_charging_day` status and then call the RecurringContribution::Subscriptions::Create service passing each juntos's subscription found. This way, all the scheduled subscriptions will be created on the Pagarme's database. 