### PR TITLE
Refactor the specs that are making the build fail sporadically

### DIFF
--- a/spec/controllers/admin/projects_controller_spec.rb
+++ b/spec/controllers/admin/projects_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Admin::ProjectsController, type: :controller do
-  subject{ response }
+  subject { response }
   let(:admin) { create(:user, admin: true) }
-  let(:current_user){ admin }
+  let(:current_user) { admin }
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)
@@ -11,73 +11,63 @@ RSpec.describe Admin::ProjectsController, type: :controller do
   end
 
   describe 'PUT approve' do
-    let(:project) { create(:project, state: 'in_analysis') }
-    subject { project.online? }
+    let(:project) { create(:project, :in_analysis) }
+    before        { put :approve, id: project, locale: :pt }
 
-    before do
-      put :approve, id: project, locale: :pt
-    end
-
-    it do
-      project.reload
-      is_expected.to eq(true)
-    end
+    it { expect(project.reload).to be_online }
   end
 
   describe 'PUT reject' do
-    let(:project) { create(:project, state: 'in_analysis') }
-    subject { project.rejected? }
+    let(:project)       { create(:project, :in_analysis) }
+    let(:reject_reason) { 'Lorem Ipsum' }
 
     before do
-      put :reject, id: project, locale: :pt
-      project.reload
+      put :reject, id: project, locale: :pt, project: { reject_reason: reject_reason }
     end
 
-    xit { is_expected.to eq(true) }
+    it { expect(project.reload).to be_rejected }
+
+    it { expect(project.reload.reject_reason).to eq('Lorem Ipsum') }
   end
 
   describe 'PUT push_to_draft' do
-    let(:project) { create(:project, state: 'online') }
-    subject { project.draft? }
+    let(:project) { create(:project, :online) }
 
     before do
       allow(controller).to receive(:current_user).and_return(admin)
       put :push_to_draft, id: project, locale: :pt
     end
 
-    it do
-      project.reload
-      is_expected.to eq(true)
-    end
+    it { expect(project.reload).to be_draft }
   end
 
   describe 'PUT push_to_trash' do
-    let(:project) { create(:project, state: 'draft') }
-    subject{ project.reload.deleted? }
+    let(:project) { create(:project, :draft) }
 
     before do
       allow(controller).to receive(:current_user).and_return(admin)
       put :push_to_trash, id: project, locale: :pt
     end
 
-    it{ is_expected.to eq(true) }
+    it { expect(project.reload).to be_deleted }
   end
 
+  describe 'GET index' do
+    context 'when a user is not logged in' do
+      let(:current_user) { nil }
+      before             { get :index, locale: :pt }
 
-  describe "GET index" do
-    context "when a user is not logged in" do
-      let(:current_user){ nil }
-      before do
-        get :index, locale: :pt
-      end
-      it{ is_expected.to redirect_to new_user_registration_path }
+      it { is_expected.to redirect_to new_user_registration_path }
     end
 
-    context "when a user is logged as admin" do
-      let!(:url_namespace_channel){ create(:channel) }
-      let!(:out_of_channel_projects){ create_list(:project, 3) }
-      let!(:channel_projects){ create_list(:project, 2, channels: [url_namespace_channel]) }
-      let!(:channel_failed_project){ create(:project,  channels: [url_namespace_channel], state: 'deleted') }
+    context 'when a user is logged as admin' do
+      let(:url_namespace_channel) { create(:channel) }
+      let(:non_deleted_projects)  { ['project_out_of_a_channel', 'project_in_a_channel'] }
+      before do
+        create(:project, name: 'project_out_of_a_channel')
+        create(:project, channels: [url_namespace_channel], name: 'project_in_a_channel')
+        create(:project, :deleted, channels: [url_namespace_channel], name: 'deleted_project')
+      end
 
       context 'is inside a channel' do
         before do
@@ -86,10 +76,10 @@ RSpec.describe Admin::ProjectsController, type: :controller do
         end
 
         it "should return only projects registered on the admin's current channel" do
-          expect(assigns(:projects)).to eq(channel_projects)
+          expect(assigns(:projects).map(&:name)).to match_array('project_in_a_channel')
         end
 
-        its(:status){ should == 200 }
+        it { is_expected.to have_http_status(200) }
       end
 
       context 'is not inside a channel' do
@@ -99,65 +89,69 @@ RSpec.describe Admin::ProjectsController, type: :controller do
         end
 
         it 'should return all non-deleted projects' do
-          expect(assigns(:projects)).to eq(out_of_channel_projects + channel_projects)
+          expect(assigns(:projects).map(&:name)).to match_array(non_deleted_projects)
         end
 
-        its(:status){ should == 200 }
+        it { is_expected.to have_http_status(200) }
       end
     end
   end
 
   describe '.collection' do
-    let(:project) { create(:project, name: 'Project for search') }
-    context "when there is a match" do
-      before do
-        get :index, locale: :pt, pg_search: 'Project for search'
-      end
-      it{ expect(assigns(:projects)).to eq([project]) }
+    before do
+      create(:project, name: 'Project for search')
+      create(:project, name: 'Project_name_test')
     end
 
-    context "when there is no match" do
-      before do
-        get :index, locale: :pt, pg_search: 'Foo Bar'
-      end
-      it{ expect(assigns(:projects)).to eq([]) }
+    context 'when there is a match' do
+      before { get :index, locale: :pt, pg_search: 'Project for search' }
+
+      it { expect(assigns(:projects).map(&:name)).to eq(['Project for search']) }
+    end
+
+    context 'when there is no match' do
+      before { get :index, locale: :pt, pg_search: 'Non-existing Project' }
+
+      it { expect(assigns(:projects)).to be_empty }
     end
   end
 
-  describe "DELETE destroy" do
-    let(:project) { create(:project, state: 'draft') }
+  describe 'DELETE destroy' do
+    let(:project) { create(:project, :draft) }
+    before        { delete :destroy, id: project, locale: :pt }
 
     context "when I'm not logged in" do
-      let(:current_user){ nil }
-      before do
-        delete :destroy, id: project, locale: :pt
+      let(:current_user) { nil }
+
+      it { is_expected.to redirect_to new_user_registration_path }
+
+      it 'should remain in the draft state' do
+        expect(project.reload).to be_draft
       end
-      it{ is_expected.to redirect_to new_user_registration_path }
     end
 
     context "when I'm logged as admin" do
-      before do
-        delete :destroy, id: project, locale: :pt
-      end
-
-      its(:status){ should redirect_to admin_projects_path }
+      it { is_expected.to redirect_to admin_projects_path }
 
       it 'should change state to deleted' do
-        expect(project.reload.deleted?).to eq(true)
+        expect(project.reload).to be_deleted
       end
     end
   end
 
-  describe "POST move_project_to_channel" do
-    let (:project) { FactoryGirl.create(:project) }
-    let (:channel) { FactoryGirl.create(:channel) }
+  describe 'POST move_project_to_channel' do
+    let(:project) { create(:project, name: 'project_moved_to_channel') }
+    let(:channel) { create(:channel) }
+    subject       { channel.reload.projects.map(&:name) }
 
-    it "Adds project to channel" do
-      expect(channel.projects).to be_empty
+    context 'when there is no project in the channel' do
+      it { is_expected.to be_empty }
+    end
 
-      post :move_project_to_channel, { :project_id => project.id, :channel_id => channel.id }
+    context 'when moving a project to the channel' do
+      before { post :move_project_to_channel, { :project_id => project.id, :channel_id => channel.id } }
 
-      expect(channel.reload.projects).to include(project)
+      it { is_expected.to match_array('project_moved_to_channel') }
     end
   end
 

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Contribution, type: :model do
 
       it "returns the contributions in the right order of Project.search_on_name's against param rules" do
         all_great_project_contributions = great_project_contributions.map { |c| c.project_value.to_f }
-        expect(all_great_project_contributions).to eq([50.0, 40.0, 30.0])
+        expect(all_great_project_contributions).to contain_exactly(50.0, 40.0, 30.0)
       end
     end
 

--- a/spec/models/recurring_contribution_spec.rb
+++ b/spec/models/recurring_contribution_spec.rb
@@ -48,14 +48,18 @@ RSpec.describe RecurringContribution do
 
   describe 'state changes' do
     describe '#cancel' do
-      Timecop.freeze do
-        subject { contribution.cancel }
-
-        it 'updates the cancelled_at field to current date' do
-          expect { subject }
-            .to change { contribution.reload.cancelled_at.to_s }
-            .from('').to(Time.current.to_s)
+      around do |test_case|
+        Timecop.freeze do
+          test_case.run
         end
+      end
+
+      subject { contribution.cancel }
+
+      it 'updates the cancelled_at field to current date' do
+        expect { subject }
+          .to change { contribution.reload.cancelled_at.to_s }
+          .from('').to(Time.current.to_s)
       end
     end
   end


### PR DESCRIPTION
Some assertions are making the build fail sporadically. It is because the array order matter in those assertions, when it should not.