### PR TITLE
Remove `protected_attributes` gem and using rails strong_parameters instead

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ ruby '2.1.8'
 
 gem 'rails', '~> 4.1.14'
 
-gem 'protected_attributes', '~> 1.0.5' # When upgrade to strong_parameters, remove this gem.
 gem 'rails-observers', '~> 0.1.2'
 
 gem 'sidekiq',  '~> 3.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,8 +392,6 @@ GEM
       pg (>= 0.17)
       rails (>= 4.0)
       responders
-    protected_attributes (1.0.8)
-      activemodel (>= 4.0.1, < 5.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -660,7 +658,6 @@ DEPENDENCIES
   pg_search (~> 1.0.6)
   poltergeist
   postgres-copy
-  protected_attributes (~> 1.0.5)
   pry
   pry-remote
   pundit
@@ -704,4 +701,4 @@ RUBY VERSION
    ruby 2.1.8p440
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/app/controllers/admin/channels_controller.rb
+++ b/app/controllers/admin/channels_controller.rb
@@ -4,11 +4,23 @@ class Admin::ChannelsController < Admin::BaseController
   defaults resource_class: Channel, collection_name: 'channels', instance_name: 'channel'
 
   def create
+    @channel = Channel.new(channel_params)
     create! { admin_channels_path }
   end
 
   def update
-    update! { admin_channels_path }
+    @channel = Channel.find(params[:id])
+    if @channel.update(channel_params)
+      redirect_to admin_channels_path
+    else
+      render 'new'
+    end
   end
 
+  private
+
+  def channel_params
+    allow_attributes = %i(name email description recurring custom_submit_text permalink category_id)
+    params[:channel].permit(allow_attributes)
+  end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -50,16 +50,16 @@ class ProjectsController < ApplicationController
     options = {user: current_user}
     options.merge!(channels: [channel]) if channel
 
-    @project = Project.new params[:project].merge(options)
+    @project = Project.new(user: current_user, new_record: true)
     authorize @project
-    @project_create = Project::Create.new(current_user, params[:project].merge(options))
+    response = Project::Create.new(current_user, project_params.merge(options))
 
-    if @project_create.process
-      @project = @project_create.project
+    if response.process
+      @project = response.project
       session[:new_project] = true
       redirect_to project_by_slug_path(@project.permalink, anchor: 'basics')
     else
-      flash[:alert] = @project_create.project.errors.full_messages.to_sentence
+      flash[:alert] = response.project.errors.full_messages.to_sentence
       render :new
     end
   end

--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -25,8 +25,11 @@ class RewardsController < ApplicationController
   end
 
   def create
-    @reward = Reward.new(params[:reward].merge(project: parent))
+    @reward = Reward.new(project_id: params[:project_id])
+
     authorize resource
+
+    @reward = Reward.new(reward_params)
     create!(notice: t('project.update.success')) { project_by_slug_path(permalink: parent.permalink) + '#dashboard_rewards' }
   end
 
@@ -44,5 +47,9 @@ class RewardsController < ApplicationController
   private
   def permitted_params
     params.permit(policy(resource).permitted_attributes)
+  end
+
+  def reward_params
+    permitted_params[:reward].merge(project_id: params[:project_id])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -76,7 +76,7 @@ class UsersController < ApplicationController
 
   def update_password
     authorize resource
-    if @user.update_with_password(params[:user])
+    if @user.update_with_password(permitted_password_params)
       flash[:notice] = t('users.current_user_fields.updated')
     else
       flash[:error] = @user.errors.full_messages.to_sentence
@@ -103,6 +103,10 @@ class UsersController < ApplicationController
 
   def permitted_params
     params.permit(policy(resource).permitted_attributes)
+  end
+
+  def permitted_password_params
+    params[:user].permit(:current_password, :password, :password_confirmation)
   end
 
   def update_staffs

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -1,5 +1,4 @@
 class Authorization < ActiveRecord::Base
-  attr_accessible :oauth_provider, :oauth_provider_id, :uid, :user_id, :user
   belongs_to :user
   belongs_to :oauth_provider
 

--- a/app/models/channels_subscriber.rb
+++ b/app/models/channels_subscriber.rb
@@ -1,6 +1,4 @@
 class ChannelsSubscriber < ActiveRecord::Base
-  attr_accessible :user_id, :channel_id, :user, :channel
-
   belongs_to :channel
   belongs_to :user
 

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -86,8 +86,6 @@ class Contribution < ActiveRecord::Base
     with_states(['confirmed', 'refunded', 'requested_refund']).where(project_id: project)
   }
 
-  attr_protected :state
-
   def self.between_values(start_at, ends_at)
     return all unless start_at.present? && ends_at.present?
     where("value between ? and ?", start_at, ends_at)

--- a/app/models/contribution_report.rb
+++ b/app/models/contribution_report.rb
@@ -1,4 +1,3 @@
 class ContributionReport < ActiveRecord::Base
-  attr_accessible :title, :body
   acts_as_copy_target
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,19 +11,6 @@ class User < ActiveRecord::Base
                   :trackable,
                   :omniauthable
 
-  attr_accessible :email, :password, :password_confirmation, :remember_me,
-                  :name, :image_url, :uploaded_image, :bio, :newsletter, :full_name,
-                  :address_street, :address_number, :address_complement, :address_city,
-                  :address_neighbourhood, :address_state, :address_zip_code, :phone_number,
-                  :cpf, :state_inscription, :locale, :twitter, :facebook_link, :other_link,
-                  :moip_login, :deactivated_at, :reactivate_token, :bank_account_attributes,
-                  :access_type, :responsible_name, :responsible_cpf, :mobile_phone, :gender,
-                  :staffs, :job_title, :birth_date, :admin, :original_doc1_url,
-                  :original_doc2_url, :original_doc3_url, :original_doc4_url,
-                  :original_doc5_url, :original_doc6_url, :original_doc7_url,
-                  :original_doc8_url, :original_doc9_url, :original_doc10_url,
-                  :original_doc11_url, :original_doc12_url, :original_doc13_url
-
   enum access_type: [:individual, :legal_entity]
   enum gender:      [:male, :female]
 

--- a/app/services/project/crud.rb
+++ b/app/services/project/crud.rb
@@ -3,7 +3,7 @@ class Project::Crud
 
   def initialize(current_user, params)
     @current_user = current_user
-    @params = params
+    @params = params.with_indifferent_access
   end
 
   def valid?
@@ -31,6 +31,6 @@ class Project::Crud
   end
 
   def online_days_param
-    @params['online_days'].to_i
+    @params[:online_days].to_i
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,8 +42,5 @@ module Catarse
       :project_post_observer, :project_observer, :channel_post_observer,
       :mixpanel_observer, '::CatarseMonkeymail::MonkeyProjectObserver',
     ]
-
-    # TODO: remove
-    config.active_record.whitelist_attributes = false
   end
 end

--- a/spec/controllers/admin/channels_controller_spec.rb
+++ b/spec/controllers/admin/channels_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Admin::ChannelsController, type: :controller do
+  let(:admin)        { create(:user, admin: true) }
+  let(:current_user) { admin }
+  before  { sign_in current_user }
+
+  describe 'POST create' do
+    let(:channel) { attributes_for(:channel, recurring: true, custom_submit_text: 'custom_text') }
+
+    it { expect{ put(:create, channel: channel, locale: :pt) }.to change(Channel, :count).by(1) }
+  end
+
+  describe 'PUT update' do
+    let(:channel)         { create(:channel, recurring: true, custom_submit_text: 'custom_text') }
+    let(:updated_channel) { Channel.find(channel.id) }
+    let(:category)        { create(:category) }
+    let(:channel_attributes) do
+      {
+        category_id: category.id,
+        name: 'new_name',
+        email: 'email_channel_123@foo.bar',
+        description: 'Foo description bar',
+        permalink: 'foo_permalink_test_bar',
+        recurring: false,
+        custom_submit_text: 'update_custom_text'
+      }
+    end
+
+    before do
+      put(:update, id: channel.id, channel: channel_attributes, locale: :pt)
+    end
+
+    it { expect(updated_channel).to have_attributes(channel_attributes) }
+  end
+end

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe Channel, type: :model do
   describe "Validations & Assoaciations" do
 
     [:name, :description, :permalink, :category_id].each do |attribute|
-      it { is_expected.to validate_presence_of      attribute }
-      it { is_expected.to allow_mass_assignment_of  attribute }
+      it { is_expected.to validate_presence_of attribute }
     end
 
     xit "validates uniqueness of permalink" do

--- a/spec/services/project/update_spec.rb
+++ b/spec/services/project/update_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe Project::Update do
   it_behaves_like 'when the validation of online_days needs to be done' do
-     let(:service) { :update }
+    let(:service) { :update }
   end
 
   describe ".process" do
     let(:project) { create(:project, online_days: 10) }
-    let(:params) { build(:project, online_days: 61).attributes }
+    let(:params) { attributes_for(:project, online_days: 61) }
     let(:update_admin_service) { Project::Update.new(user, params, project) }
     let(:service_process) { update_admin_service.process }
     let(:project_with_61_online_days) { build(:project, online_days: 61) }
@@ -32,7 +32,7 @@ RSpec.describe Project::Update do
         let(:persisted_project) { Project.find(update_admin_service.project.id) }
 
         context "when online_days has a value between 0 and 60" do
-          let(:params) { build(:project, online_days: 60).attributes }
+          let(:params) { attributes_for(:project, online_days: 60) }
 
           it "should return an updated project" do
             expect(persisted_project.online_days).to eq 60
@@ -40,7 +40,7 @@ RSpec.describe Project::Update do
         end
 
         context "when online_days has a value greater than 61" do
-          let(:params) { build(:project, online_days: 61).attributes }
+          let(:params) { attributes_for(:project, online_days: 61) }
 
           it 'should not update the project' do
             expect(persisted_project.online_days).to eq 10


### PR DESCRIPTION
When updating to rails 4, this gem was added to avoid removing `attr_accessible` and `attr_protected` methods from models.

It removes to use rails 4+ `strong_paramteres` intead