### PR TITLE
Update project edit rules

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -189,7 +189,7 @@ class ProjectsController < ApplicationController
   end
 
   def resource
-    @project ||= (params[:permalink].present? ? Project.by_permalink(params[:permalink]).first! : Project.find(params[:id]))
+    @project ||= (params[:permalink].present? ? Project.by_permalink(params[:permalink]).first! : Project.find(params[:id])).decorate
   end
 
   def use_catarse_boostrap

--- a/app/decorators/project_decorator.rb
+++ b/app/decorators/project_decorator.rb
@@ -1,5 +1,5 @@
 class ProjectDecorator < Draper::Decorator
-  decorates :project
+  delegate_all
   include Draper::LazyHelpers
 
   def remaining_text
@@ -116,6 +116,10 @@ class ProjectDecorator < Draper::Decorator
     else
       I18n.t('projects.partner_message', partner: source.partner_name)
     end
+  end
+
+  def editable_field?
+    source.visible? && source.user == current_user
   end
 
   private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -41,12 +41,12 @@ class Project < ActiveRecord::Base
   has_many :subgoals, -> { order 'value DESC' }
 
   accepts_nested_attributes_for :project_images,
-    limit: CatarseSettings[:project_images_limit].to_i,
+    limit: -> { CatarseSettings[:project_images_limit].to_i },
     allow_destroy: true,
     reject_if: :reject_project_image
 
   accepts_nested_attributes_for :project_partners,
-    limit: CatarseSettings[:project_partners_limit].to_i,
+    limit: -> { CatarseSettings[:project_partners_limit].to_i },
     allow_destroy: true,
     reject_if: :reject_project_image
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -344,6 +344,10 @@ class Project < ActiveRecord::Base
     project_partners.count == CatarseSettings[:project_partners_limit].to_i
   end
 
+  def visible?
+    %w(draft rejected deleted in_analysis).exclude?(state)
+  end
+
   private
 
   def check_url

--- a/app/views/juntos_bootstrap/projects/_dashboard_project.html.slim
+++ b/app/views/juntos_bootstrap/projects/_dashboard_project.html.slim
@@ -134,7 +134,7 @@
                   max_file_size: 5.megabytes, data: {s3_uploader: true},
                   key: "uploads/project/uploaded_image/#{@project.id}/${filename}" do
                     = file_field_tag :file, id: 'uploaded-image-upload', class: 'w-input text-field',
-                      data: {url: s3_uploader_url}
+                      data: {url: s3_uploader_url}, disabled: @project.editable_field?
 
                 = hidden_field_tag 'project[original_uploaded_image]', nil,
                   data: {image_field: true}
@@ -147,7 +147,7 @@
                   max_file_size: 5.megabytes, data: {s3_uploader: true},
                   key: "uploads/project/uploaded_cover_image/#{@project.id}/${filename}" do
                     = file_field_tag :file, id: 'uploaded-cover-image-upload',  class: 'w-input text-field',
-                      data: {url: s3_uploader_url}
+                      data: {url: s3_uploader_url}, disabled: @project.editable_field?
 
                 = hidden_field_tag 'project[original_uploaded_cover_image]', nil,
                   data: {image_field: true}
@@ -156,7 +156,7 @@
               label.field-label.fontweight-semibold= t('.headline')
               label.field-label.fontsize-smallest.fontcolor-secondary= t('.headline_hint')
             .w-col.w-col-7
-              = form.input_field :headline, as: :text, class: 'positive'
+              = form.input_field :headline, as: :text, class: 'positive', disabled: @project.editable_field?
         .w-col.w-col-4
           = render @project
   .divider

--- a/app/views/juntos_bootstrap/projects/_project_basics.html.slim
+++ b/app/views/juntos_bootstrap/projects/_project_basics.html.slim
@@ -20,24 +20,24 @@
                     .w-col.w-col-12
                       label.field-label.fontweight-semibold for="name-8"= t('.online_date')
                     .w-col.w-col-12
-                      = form.input :online_date, as: :datetime, label: '', include_blank: true
+                      = form.input :online_date, as: :datetime, label: '', include_blank: true, disabled: @project.editable_field?
                 - if policy(@project).edit_partner?
                   .w-row.u-marginbottom-20.card.card-terciary
                     .w-col.w-col-5
                       label.field-label.fontweight-semibold for="name-8"= t('.partner_name')
                     .w-col.w-col-7
-                      = form.input_field :partner_name, as: :string, class: 'positive'
+                      = form.input_field :partner_name, as: :string, class: 'positive', disabled: @project.editable_field?
                   .w-row.u-marginbottom-20.card.card-terciary
                     .w-col.w-col-5
                       label.field-label.fontweight-semibold for="name-8"= t('.partner_message')
                     .w-col.w-col-7
-                      = form.input_field :partner_message, as: :string, class: 'positive'
+                      = form.input_field :partner_message, as: :string, class: 'positive', disabled: @project.editable_field?
               .w-row.u-marginbottom-30.card.card-terciary
                 .w-col.w-col-5.w-sub-col
                   label.field-label.fontweight-semibold for="name-8"= t('.name')
                   label.field-label.fontsize-smallest.fontcolor-secondary for="name-8"=t('.name_label')
                 .w-col.w-col-7
-                  = form.input_field :name, as: :string, class: 'positive'
+                  = form.input_field :name, as: :string, class: 'positive', disabled: @project.editable_field?
                     .text-error.fontsize-smallest
                       span.fa.fa-exclamation-triangle .
                       | \&nbsp;This is some text inside of a div block.
@@ -50,14 +50,14 @@
                     .w-col.w-col-4.w-col-small-6.w-col-tiny-6.text-field.prefix.no-hover
                       .fontcolor-secondary.u-text-center.fontsize-smallest juntos.com.vc/
                     .w-col.w-col-8.w-col-small-6.w-col-tiny-6
-                      = form.input_field :permalink, as: :string, class: 'postfix positive', required: false
+                      = form.input_field :permalink, as: :string, class: 'postfix positive', required: false, disabled: @project.editable_field?
               - unless @channel && @channel.recurring?
                 .w-row.u-marginbottom-30.card.card-terciary
                   .w-col.w-col-5.w-sub-col
                     label.field-label.fontweight-semibold for="name-8"= t('.category')
                     label.field-label.fontsize-smallest.fontcolor-secondary for="name-8"= t('.category_label')
                   .w-col.w-col-7
-                    = form.association :category, as: :select, collection: Category.order(:name_pt), prompt: t('simple_form.prompts.project.category'), class: 'w-select text-field positive', label: '', required: false, hint: ''
+                    = form.association :category, as: :select, collection: Category.order(:name_pt), prompt: t('simple_form.prompts.project.category'), class: 'w-select text-field positive', label: '', required: false, hint: '', disabled: @project.editable_field?
               .w-row.u-marginbottom-30.card.card-terciary
                 .w-col.w-col-5.w-sub-col
                   label.field-label.fontweight-semibold for="project_goal"= t('.value')
@@ -68,7 +68,7 @@
                     .w-col.w-col-4.w-col-small-6.w-col-tiny-6.text-field.prefix.no-hover
                       .fontcolor-secondary.u-text-center.fontsize-base.lineheight-tightest R$
                     .w-col.w-col-8.w-col-small-6.w-col-tiny-6
-                      = form.input_field :goal, as: :string, class: 'positive'
+                      = form.input_field :goal, as: :string, class: 'positive', disabled: @project.editable_field?
               - unless @channel && @channel.recurring?
                 .w-row.card.card-terciary
                   .w-col.w-col-5.w-sub-col
@@ -79,7 +79,7 @@
                   .w-col.w-col-7
                     .w-row
                       .w-col.w-col-8.w-col-small-6.w-col-tiny-6
-                        = form.input_field :online_days, class: 'prefix positive', as: :string
+                        = form.input_field :online_days, class: 'prefix positive', as: :string, disabled: @project.editable_field?
                       .w-col.w-col-4.w-col-small-6.w-col-tiny-6.text-field.postfix.no-hover
                         .fontcolor-secondary.u-text-center.fontsize-base.lineheight-tightest = t('.online_days_addon')
               - if current_user.admin?
@@ -88,7 +88,7 @@
                     label.field-label.fontweight-semibold for="name-8"=t('.available_for_contributions')
                     label.field-label.fontsize-smallest.fontcolor-secondary for="name-8"= t('.available_for_contributions_label')
                   .w-col.w-col-7
-                        = form.input :available_for_contribution, as: :boolean, label: '', input_html: { class: 'w-col w-col-12' }
+                        = form.input :available_for_contribution, as: :boolean, label: '', input_html: { class: 'w-col w-col-12' }, disabled: @project.editable_field?
 
         = render 'project_sidebar_faq'
 
@@ -98,5 +98,5 @@
         .w-row
           .w-col.w-col-4
           .w-col.w-col-4
-            = form.button :submit, t('.form.submit'), class:'btn btn-large'
+            = form.button :submit, t('.form.submit'), class:'btn btn-large', disabled: @project.editable_field?
           .w-col.w-col-4

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -100,52 +100,50 @@ RSpec.describe ProjectsController, type: :controller do
     end
 
     shared_examples_for "protected project" do
-      let(:project){ create(:project, name: 'Foo bar', state: 'draft') }
+      let(:project_attributes) do
+        {
+          headline:  'updated_headline',
+          name:      'updated_name',
+          permalink: 'updated_permalink'
+        }
+      end
 
-      before { put :update, id: project.id, project: { name: 'My Updated Title' }, locale: :pt }
+      before do
+        put :update, id: project.id, project: project_attributes, locale: :pt
+        project.reload
+      end
 
-      it { expect(project.reload.name).to eq('Foo bar') }
+      it { expect(project.headline).not_to eq('updated_headline') }
+
+      it { expect(project.name).not_to eq('updated_name') }
+
+      it { expect(project.permalink).not_to eq('updated_permalink') }
     end
 
     context "when user is a guest" do
+      let(:project) { create(:project, :draft) }
+
       it_should_behave_like "protected project"
     end
 
     context "when user is a project owner" do
-      let(:current_user){ project.user }
+      let(:current_user) { project.user }
 
-      context "when project is offline" do
+      context "and the project is offline" do
         it_should_behave_like "updatable project"
       end
 
-      context "when project is online" do
-        let(:project) { create(:project, state: 'online') }
+      context "and the project is online" do
+        let(:project) { create(:project, :online) }
 
-        before do
-          allow(controller).to receive(:current_user).and_return(project.user)
-        end
-
-        context "when I try to update the project name and the about field" do
-          before{ put :update, id: project.id, project: { name: 'new_title', about: 'new_description' }, locale: :pt }
-          it "should update title" do
-            project.reload
-
-            expect(project.name).to eq('new_title')
-          end
-        end
-
-        context "when I try to update only the about field" do
-          before{ put :update, id: project.id, project: { about: 'new_description' }, locale: :pt }
-          it "should update it" do
-            project.reload
-            expect(project.about).to eq('new_description')
-          end
-        end
+        it_should_behave_like "protected project"
       end
     end
 
     context "when user is a registered user" do
-      let(:current_user){ create(:user, admin: false) }
+      let(:current_user) { create(:user, admin: false) }
+      let(:project)      { create(:project, :online) }
+
       it_should_behave_like "protected project"
     end
 

--- a/spec/decorators/project_decorator_spec.rb
+++ b/spec/decorators/project_decorator_spec.rb
@@ -287,5 +287,72 @@ RSpec.describe ProjectDecorator do
     end
 
   end
+
+  describe "#editable_field?" do
+    let(:current_user) { create(:user) }
+    let(:project) { create(:project, :draft, user: current_user) }
+    before { sign_in current_user }
+
+    context "when there is no user" do
+      let(:current_user) { nil }
+      let(:project) { create(:project) }
+
+      it { expect(project.decorate).not_to be_editable_field }
+    end
+
+    context "when the current user does not own the project" do
+      let(:project) { create(:project) }
+
+      it { expect(project.decorate).not_to be_editable_field }
+    end
+
+    context "when the current user owns the project" do
+      context "and the project is 'draft'" do
+        it { expect(project.decorate).not_to be_editable_field }
+      end
+
+      context "and the project is 'rejected'" do
+        let(:project) { create(:project, :rejected, user: current_user) }
+
+        it { expect(project.decorate).not_to be_editable_field }
+      end
+
+      context "and the project is 'deleted'" do
+        let(:project) { create(:project, :deleted, user: current_user) }
+
+        it { expect(project.decorate).not_to be_editable_field }
+      end
+
+      context "and the project is 'in_analysis'" do
+        let(:project) { create(:project, :in_analysis, user: current_user) }
+
+        it { expect(project.decorate).not_to be_editable_field }
+      end
+
+      context "and the project is 'online'" do
+        let(:project) { create(:project, :online, user: current_user) }
+
+        it { expect(project.decorate).to be_editable_field }
+      end
+
+      context "and the project is 'waiting_funds'" do
+        let(:project) { create(:project, :waiting_funds, user: current_user) }
+
+        it { expect(project.decorate).to be_editable_field }
+      end
+
+      context "and the project is 'successful'" do
+        let(:project) { create(:project, :successful, user: current_user) }
+
+        it { expect(project.decorate).to be_editable_field }
+      end
+
+      context "and the project is 'failed'" do
+        let(:project) { create(:project, :failed, user: current_user) }
+
+        it { expect(project.decorate).to be_editable_field }
+      end
+    end
+  end
 end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1854,6 +1854,56 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  describe "#visible?" do
+    context "when the project is 'draft'" do
+      let(:project) { create(:project, :draft) }
+
+      it { expect(project).not_to be_visible }
+    end
+
+    context "when the project is 'rejected'" do
+      let(:project) { create(:project, :rejected) }
+
+      it { expect(project).not_to be_visible }
+    end
+
+    context "when the project is 'deleted'" do
+      let(:project) { create(:project, :deleted) }
+
+      it { expect(project).not_to be_visible }
+    end
+
+    context "when the project is 'in_analysis'" do
+      let(:project) { create(:project, :in_analysis) }
+
+      it { expect(project).not_to be_visible }
+    end
+
+    context "when the project is 'online'" do
+      let(:project) { create(:project, :online) }
+
+      it { expect(project).to be_visible }
+    end
+
+    context "when the project is 'successful'" do
+      let(:project) { create(:project, :successful) }
+
+      it { expect(project).to be_visible }
+    end
+
+    context "when the project is 'failed'" do
+      let(:project) { create(:project, :failed) }
+
+      it { expect(project).to be_visible }
+    end
+
+    context "when the project is 'waiting_funds'" do
+      let(:project) { create(:project, :waiting_funds) }
+
+      it { expect(project).to be_visible }
+    end
+  end
+
   describe ".state_names" do
     let(:states) { [:draft, :rejected, :online, :successful, :waiting_funds, :failed, :in_analysis] }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe User, type: :model do
     subject { User.with_visible_projects }
 
     it "should return only users who has visible projects" do
-      is_expected.to eq(users_with_visible_project)
+      is_expected.to match_array(users_with_visible_project)
     end
   end
 


### PR DESCRIPTION
When the project is visible to users (project state is online, successful...), some attributes should no longer be able to be editable by non-admin users.