### PR TITLE
Adding the plans tab in the project's dashboard

### DIFF
--- a/app/assets/javascripts/app/project.js
+++ b/app/assets/javascripts/app/project.js
@@ -12,6 +12,7 @@ App.addChild('Project', _.extend({
     this.route('about');
     this.route('basics');
     this.route('dashboard_project');
+    this.route('dashboard_project_plans');
     this.route('dashboard_rewards');
     this.route('dashboard_subgoals');
     this.route('posts');
@@ -41,7 +42,7 @@ App.addChild('Project', _.extend({
     if($tab.length > 0){
       this.onTabClick({ currentTarget: $tab });
 
-      var links = ['project_metrics_link', 'project_reports_link', 'basics_link', 'dashboard_project_link', 'dashboard_rewards_link', 'dashboard_subgoals_link', 'project_bank_info_link'];
+      var links = ['project_metrics_link', 'project_reports_link', 'basics_link', 'dashboard_project_link', 'dashboard_project_plans_link', 'dashboard_rewards_link', 'dashboard_subgoals_link', 'project_bank_info_link'];
 
       $('[data-project-owner-sidebar]').toggle( ($.inArray($tab.prop('id'), links) == -1) );
     }

--- a/app/assets/stylesheets/juntos_bootstrap/_colors.sass
+++ b/app/assets/stylesheets/juntos_bootstrap/_colors.sass
@@ -4,6 +4,7 @@
 // Colors by name, with descriptive purpose
 $gray-one: #F1F4F4
 $gray-two: #F1F2F3
+$gray-three: #E6E6E6
 $border-gray: #E9E9EC
 $border-strong: #DDDDDD
 $border-yellow: #FFB74D

--- a/app/assets/stylesheets/juntos_bootstrap/_main.scss
+++ b/app/assets/stylesheets/juntos_bootstrap/_main.scss
@@ -500,6 +500,41 @@ p {
     font-weight: normal;
   }
 }
+
+.plans-container {
+  .plan {
+    cursor: pointer;
+
+    .check-box {
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+
+    .content {
+      background-color: $gray-three;
+      border-radius: 5px;
+      box-shadow: 1px 1px 1px $border-strong;
+      height: 120px;
+    }
+
+    .amount {
+      margin-bottom: 0;
+    }
+
+    .recurrence {
+      padding: 0 10px;
+    }
+
+    hr {
+      background-color: $border-strong;
+      border: 0;
+      height: 1px;
+      width: 70%;
+    }
+  }
+}
+
 .warning {
   position: absolute;
   top: 0px;
@@ -2159,6 +2194,9 @@ p {
 .u-marginleft-10 {
   margin-left: 10px;
 }
+.u-marginleft-5 {
+  margin-left: 5px;
+}
 .u-right {
   float: right;
 }
@@ -2695,7 +2733,6 @@ p {
 .btn-send-draft {
   display: inline-block;
   width: 210px;
-  margin-top: -4px;
   float: right;
 }
 .link-edit {
@@ -3303,8 +3340,6 @@ section.devise-body-section .access-type-field input {
     background-color: #fff;
     text-align: center;
   }
-
-
   .project-stats-digits {
     margin-bottom: 24px;
     padding-top: 14px;

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -9,4 +9,6 @@ class Plan < ActiveRecord::Base
             multiple: true, i18n_scope: "enumerize.plan.payment_methods"
 
   validates_presence_of :plan_code, :name, :amount, :payment_methods
+
+  has_and_belongs_to_many :projects, join_table: 'projects_plans'
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -31,6 +31,7 @@ class Project < ActiveRecord::Base
   belongs_to :user
   belongs_to :category
   has_and_belongs_to_many :channels
+  has_and_belongs_to_many :plans, join_table: 'projects_plans'
   has_one :project_total
   has_many :rewards
   has_many :contributions
@@ -173,6 +174,8 @@ class Project < ActiveRecord::Base
   validates_format_of :permalink, with: /\A(\w|-)*\Z/
 
   validates_presence_of :category, unless: :recurring?
+
+  validate :permit_association_with_plans?, unless: 'plans.empty?'
 
   [:between_created_at, :between_expires_at, :between_online_date, :between_updated_at].each do |name|
     define_singleton_method name do |starts_at, ends_at|
@@ -373,5 +376,9 @@ class Project < ActiveRecord::Base
 
   def reject_project_image(attributes)
     new_record? && attributes[:original_image_url].nil?
+  end
+
+  def permit_association_with_plans?
+    errors.add(:plans, :project_is_not_recurring) unless recurring?
   end
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -35,6 +35,7 @@ class ProjectPolicy < ApplicationPolicy
 
       p_attr = [
         channel_ids: [],
+        plan_ids: [],
         project_images_attributes: [:original_image_url, :caption, :id, :_destroy],
         project_partners_attributes: [:original_image_url, :link, :id, :_destroy]
       ]

--- a/app/views/juntos_bootstrap/projects/_dashboard_project_plans.html.slim
+++ b/app/views/juntos_bootstrap/projects/_dashboard_project_plans.html.slim
@@ -1,0 +1,29 @@
+.dashboard_project_plans
+  .dashboard-header.u-text-center
+    .w-container
+      .w-row
+        .w-col.w-col-2
+        .w-col.w-col-8
+          .fontweight-semibold.fontsize-large = t('.title')
+          p.fontsize-base = t('.subtitle')
+= simple_form_for @project, html: { id: 'project_form', class: 'w-form' } do |form|
+  .section
+    .w-container
+      .w-row
+        .w-col.w-col-12.plans-container
+          = form.collection_check_boxes :plan_ids, plans, :id, :amount do |cb|
+            = cb.label do
+              .w-col.w-col-2.w-col-small-3.w-col-tiny-4.plan.u-marginleft-10.u-marginbottom-10
+                .w-col.w-col-2.left.check-box
+                  = cb.check_box
+                .w.col.w-col-10.right.content
+                  .u-text-center.value
+                    p.amount.fontsize-larger.bold.u-margintop-10
+                      = cb.text.to_i
+                      span.fontsize-small.u-marginleft-5
+                        = 'R$'
+                  hr
+                  .u-text-center.recurrence.bold
+                    = t('.charging_recurrence')
+        .w-col.w-col-offset-4.w-col-tiny-offset-1.w-col-medium-offset-1.w-col-4.w-col-tiny-10.w-col-small-10.u-margintop-20
+          = form.button :submit, t('.submit'),  class:'btn btn-large js-btn-submit'

--- a/app/views/juntos_bootstrap/projects/show.html.slim
+++ b/app/views/juntos_bootstrap/projects/show.html.slim
@@ -116,13 +116,17 @@ nav.project-nav.w-hidden-main.w-hidden-medium
           span.fa.fa-check-circle
             span.u-marginleft-10 = t('.dashboard_nav.bank_info')
 
+        = link_to '#dashboard_project_plans', id: 'dashboard_project_plans_link', class: 'dashboard-nav-link' , data: {target: '#dashboard_project_plans'} do
+          span.fa.fa-check-circle
+            span.u-marginleft-10 = t('.dashboard_nav.plans')
+
       - if current_user.admin?
         = link_to '#dashboard_subgoals', id: 'dashboard_subgoals_link', class: 'dashboard-nav-link ' , data: {target: '#dashboard_subgoals'} do
           span.fa.fa-check-circle
             span.u-marginleft-10 = t('.dashboard_nav.subgoals')
       = link_to t('.dashboard_nav.preview'), @project, class: 'dashboard-nav-link'
       - if @project.draft?
-        .btn-send-draft
+        .btn-send-draft.u-margintop-10.u-marginbottom-10
            = link_to t('.dashboard_nav.send_to_analysis'), send_to_analysis_project_path(@project), class: 'btn btn-small'
 
 .w-container
@@ -158,11 +162,14 @@ nav.project-nav.w-hidden-main.w-hidden-medium
 
 
 
+
       #dashboard_rewards.content.w-hidden
         = render 'dashboard_reward'
       - if @project.recurring?
         #project_bank_info.content.w-hidden
           = render 'project_bank_info'
+        #dashboard_project_plans.content.w-hidden
+          = render(partial: 'dashboard_project_plans', collection: Plan.all, locals: { plans: Plan.all }) || t('.no_plans_available')
       - if current_user and current_user.admin?
         #dashboard_subgoals.content.w-hidden
           = render 'dashboard_subgoals'
@@ -210,8 +217,8 @@ nav.project-nav.w-hidden-main.w-hidden-medium
             .fontsize-large.fontweight-light.u-margintop-30
               = t('.contribute_project.already_contributing')
             .fontsize-smallest.fontweight-light.u-marginbottom-30
-              = link_to t('.contribute_project.cancel'), 
-                  cancel_recurring_project_path(@project), 
+              = link_to t('.contribute_project.cancel'),
+                  cancel_recurring_project_path(@project),
                   data: { confirm: t('.contribute_project.confirm') }
         - else
           - if @project.online? && !@project.expired? && @project.id != 629

--- a/config/locales/catarse_bootstrap/activerecord.en.yml
+++ b/config/locales/catarse_bootstrap/activerecord.en.yml
@@ -19,6 +19,8 @@ en:
         subscription_code: Subscription code
         payment_method: Payment method
         status: Status
+        plan: Plans
+        plan_ids: Plans
         plan_id: Plan
         user_id: User
         project_id: Project
@@ -105,6 +107,7 @@ en:
         permalink: 'URL of your project'
         traffic_sources: 'How did you hear about Juntos.com.vc?'
         recipient: 'Bank account info'
+        plans: 'Plans'
     errors:
       models:
         contribution: 'An error occurred while trying to save the contribution'
@@ -138,6 +141,8 @@ en:
               too_long: "The project's headline is too long. You can use only 140 characters"
             recipient:
               blank: 'Insert all fields in bank account info'
+            plan_ids:
+              project_is_not_recurring: 'only can be associated with recurring projects'
         user:
           attributes:
             email:

--- a/config/locales/catarse_bootstrap/activerecord.pt.yml
+++ b/config/locales/catarse_bootstrap/activerecord.pt.yml
@@ -67,6 +67,7 @@ pt:
         first_contributions: "Quem são as primeiras pessoas que você vai pedir para apoiar o seu projeto?"
         project_partners: 'Parceiros'
         recipient: 'Dados bancários'
+        plans: 'Planos'
       user/staff:
         team: 'Time'
         financial_board: 'Conselho Financeiro'
@@ -211,6 +212,8 @@ pt:
               too_long: "A frase de efeito é muito longa. Você pode usar um máximo de 140 caracteres."
             recipient:
               blank: 'Insira corretamente todos os campos de dados bancários'
+            plans:
+              project_is_not_recurring: 'podem ser associados apenas à projetos recorrentes'
         user:
           attributes:
             email:

--- a/config/locales/catarse_bootstrap/views/projects/show.en.yml
+++ b/config/locales/catarse_bootstrap/views/projects/show.en.yml
@@ -29,6 +29,11 @@ en:
         excerpt: 'Do you have any company that supports your fundraising campaign? If you have, put them right here! You can put up to 3 logos that will be displayed to the right side of the project. Remember, supporters must be of your project, not your NGO as a whole.'
         hint: 'We recommend 264x75 pixels images.'
         link: "Partner's link"
+    dashboard_project_plans:
+      title: 'Which donation plans are available for your project?'
+      subtitle: "Choose the plans that will be available for your project's donators"
+      charging_recurrence: 'Monthly charging'
+      submit: 'Add plans'
     dashboard_reward:
       title: 'Create and edit you rewards here'
       subtitle: 'Think how you will deliver them and put all this in the budget! Deliver our rewards or the reliability of your project may be impaired.'
@@ -118,11 +123,13 @@ en:
       contributions: 'donors'
       goal: achieved of %{total}
     show:
+      no_plans_available: 'No plans are available'
       all_or_nothing: 'All or nothing: Upon reaching each subject below , the tenderer guarantees the transfer of respective value'
       dashboard_nav:
         basics: 'Basics'
         project: 'Project'
         rewards: 'Rewards'
+        plans: 'Plans'
         bank_info: 'Bank info'
         subgoals: 'Subgoals'
         preview: 'Preview'

--- a/config/locales/catarse_bootstrap/views/projects/show.pt.yml
+++ b/config/locales/catarse_bootstrap/views/projects/show.pt.yml
@@ -29,6 +29,11 @@ pt:
         excerpt: 'Você tem alguma empresa que apoia a sua campanha de captação de recursos? Se você tiver, coloque o logo delas aqui! Você pode colocar até 3 logos, que serão exibidos a direita do projeto. Lembre-se: os apoiadores devem ser do seu projeto, não da sua ONG como um todo.'
         hint: 'Recomendamos imagens de 264x75 pixels.'
         link: 'Link do parceiro'
+    dashboard_project_plans:
+      title: 'Quais planos de contribuição estarão disponíveis no seu projeto?'
+      subtitle: 'Selecione quais planos estarão disponíveis aos doadores do seu projeto'
+      charging_recurrence: 'Cobrança mensal'
+      submit: 'Adicionar planos'
     dashboard_reward:
       title: 'Crie e edite aqui suas recompensas'
       subtitle: 'Pense bem como você irá entregá-las e coloque tudo isso no orçamento! Entregue suas recompensas, senão a confiabilidade do seu projeto pode ser prejudicada.'
@@ -122,10 +127,12 @@ pt:
       contributions: doadores
       goal: atingidos de %{total}
     show:
+      no_plans_available: 'Nenhum plano está disponível'
       all_or_nothing: 'Tudo ou Nada por submeta: ao atingir cada submeta abaixo, o proponente garante o repasse do respectivo valor'
       dashboard_nav:
         basics: 'Básico'
         project: 'Projeto'
+        plans: 'Planos'
         rewards: 'Recompensas'
         bank_info: 'Dados bancários'
         subgoals: 'Submetas'

--- a/db/migrate/20170102211454_create_projects_plans.rb
+++ b/db/migrate/20170102211454_create_projects_plans.rb
@@ -1,0 +1,11 @@
+class CreateProjectsPlans < ActiveRecord::Migration
+  def change
+    create_table :projects_plans do |t|
+      t.integer :project_id
+      t.integer :plan_id
+    end
+
+    add_index :projects_plans, :project_id
+    add_index :projects_plans, :plan_id
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -211,6 +211,10 @@ FactoryGirl.define do
     email "email+channel@foo.bar"
     description "Lorem Ipsum"
     sequence(:permalink) { |n| "#{n}-test-page" }
+
+    trait :recurring do
+      recurring true
+    end
   end
 
   factory :state do

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Plan, :type => :model do
     it { is_expected.to validate_presence_of(:amount) }
     it { is_expected.to validate_presence_of(:payment_methods) }
     it { is_expected.to enumerize(:payment_methods).in(:credit_card, :bank_billet) }
+    it { is_expected.to have_and_belong_to_many(:projects) }
 
     context 'when an invalid payment_method value is passed' do
       it 'should not be valid' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Project, type: :model do
     it{ is_expected.to have_many :notifications }
     it{ is_expected.to have_many :subscriptions }
     it{ is_expected.to have_and_belong_to_many :channels }
+    it{ is_expected.to have_and_belong_to_many(:plans) }
   end
 
   describe "validations" do
@@ -41,6 +42,27 @@ RSpec.describe Project, type: :model do
     it{ is_expected.not_to allow_value(0).for(:online_days) }
     it{ is_expected.not_to allow_value(61).for(:online_days) }
     xit{ is_expected.not_to allow_value('users').for(:permalink) }
+
+    describe "plans" do
+      let(:plan) { create(:plan) }
+      subject { build(:project, channels: [channel], plans: [plan]) }
+
+      context "when the project is recurring" do
+        let(:channel) { create(:channel, :recurring) }
+
+        it "can has associated plans" do
+          expect(subject).to be_valid
+        end
+      end
+
+      context "when the project is not recurring" do
+        let(:channel) { create(:channel) }
+
+        it "cannot has associated plans" do
+          expect(subject).to be_invalid
+        end
+      end
+    end
   end
 
   describe ".of_current_week" do


### PR DESCRIPTION
This tab allows the project owner and/or an admin user associates plans to their projects.

<img width="1280" alt="implemented-plans-tab" src="https://cloud.githubusercontent.com/assets/7783787/21616875/17d59538-d1c2-11e6-8c38-e57eab5cc5f6.png">
