### PR TITLE
Fix subgoal forbidden attributes by permitting attributes using the policy gem

### DIFF
--- a/app/controllers/subgoals_controller.rb
+++ b/app/controllers/subgoals_controller.rb
@@ -4,10 +4,6 @@ class SubgoalsController < ApplicationController
   belongs_to :project
   respond_to :html, :json
 
-  def index
-    render layout: false
-  end
-
   def new
     @subgoal = Subgoal.new(project: parent)
     authorize @subgoal
@@ -25,8 +21,10 @@ class SubgoalsController < ApplicationController
   end
 
   def create
-    @subgoal = Subgoal.new(params[:subgoal].merge(project: parent))
+    @subgoal = Subgoal.new(subgoal_params)
+
     authorize resource
+
     create!(notice: t('project.update.success')) { project_by_slug_path(permalink: parent.permalink) + '#dashboard_subgoals' }
   end
 
@@ -42,7 +40,13 @@ class SubgoalsController < ApplicationController
   end
 
   private
+
   def permitted_params
     params.permit(policy(resource).permitted_attributes)
+  end
+
+  def subgoal_params
+    allow = %i(color value description)
+    params[:subgoal].permit(allow).merge(project: parent)
   end
 end

--- a/app/views/juntos_bootstrap/subgoals/index.html.slim
+++ b/app/views/juntos_bootstrap/subgoals/index.html.slim
@@ -1,5 +1,0 @@
-- collection.each do |subgoal|
-
-  div[id="subgoal_#{subgoal.id}"
-    h2 = subgoal~~
-.clearfix

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,7 +57,7 @@ Rails.application.routes.draw do
         post 'sort'
       end
     end
-    resources :subgoals, only: [ :index, :create, :update, :destroy, :new, :edit ]
+    resources :subgoals, only: [ :create, :update, :destroy, :new, :edit ]
     resources :contributions, {controller: 'projects/contributions'}.merge(ssl_options) do
       member do
         put 'credits_checkout'

--- a/spec/controllers/subgoals_controller_spec.rb
+++ b/spec/controllers/subgoals_controller_spec.rb
@@ -1,5 +1,33 @@
 require 'rails_helper'
 
 RSpec.describe SubgoalsController, :type => :controller do
+  let(:project) { create(:project) }
+  let(:user)    { create(:user, admin: true) }
 
+  before  { sign_in user }
+
+  subject { response }
+
+  describe 'POST subgoal create' do
+    let(:subgoal_params) do
+      { color: 'some color', value: 20.0, description: 'some description' }
+    end
+    let(:created_project) { Project.find(project.id) }
+    let(:created_subgoal) { created_project.subgoals.last }
+    let(:redirect_page)   { project_by_slug_path(permalink: project.permalink) + '#dashboard_subgoals' }
+
+    before { post :create, project_id: project.id, subgoal: subgoal_params, locale: :pt }
+
+    context 'when the current user is admin' do
+      it { expect(created_subgoal).to have_attributes(subgoal_params) }
+
+      it { is_expected.to redirect_to(redirect_page) }
+    end
+
+    context 'when the current user is not admin' do
+      let(:user) { create(:user, admin: false) }
+
+      it { expect(created_project.subgoals).to be_empty }
+    end
+  end
 end


### PR DESCRIPTION
Permit subgoal attributes from subgoal policy permitted_attributes.

Remove the unused subgoals index route, because it was accessed when forbidden attributes error was raised and caused error.