### PR TITLE
Added predefined values for subscription charges

### DIFF
--- a/app/policies/subscription_policy.rb
+++ b/app/policies/subscription_policy.rb
@@ -1,6 +1,6 @@
 class SubscriptionPolicy < ApplicationPolicy
   CARD_PERMITTED_PARAMS = [:card_hash]
-  SUBSCRIPTION_PERMITTED_PARAMS = [:plan_id, :project_id, :user_id, :payment_method, :charging_day]
+  SUBSCRIPTION_PERMITTED_PARAMS = [:plan_id, :project_id, :user_id, :payment_method, :charging_day, :charges]
 
   def create?
     done_by_owner_or_admin?

--- a/app/views/juntos_bootstrap/projects/subscriptions/new.html.slim
+++ b/app/views/juntos_bootstrap/projects/subscriptions/new.html.slim
@@ -36,10 +36,13 @@
               .w-col.w-col-12
                 h4 = t('.form.expires_at')
             .w-row
-              .w-col.w-col-3.w-col-tiny-3
-                = form.input_field :charging_day
-              .w-col.w-col-5.u-marginleft-5
-
+              .w-col.w-col-12.w-col-tiny-3
+                = form.collection_radio_buttons :charges, Subscription.accepted_charge_options, :last, :first do |rb|
+                  = rb.label do
+                    .w-col.w-col-1.w-col-tiny-1
+                      = rb.radio_button
+                    .w-col.w-col-11.w-col-tiny-11.left
+                      = rb.text
           .w-row
             .w-col.w-col-12.w-col-tiny-12.payment-method
               h4 = t('.payment_methods')

--- a/config/locales/catarse_bootstrap/activerecord.en.yml
+++ b/config/locales/catarse_bootstrap/activerecord.en.yml
@@ -15,6 +15,11 @@ en:
       page: 'Page'
       transparency_report: 'Transparency Report'
     attributes:
+      subscription/charge_options:
+        indefinite: 'Indefinite period'
+        for_three_months: '3 months'
+        for_six_months: '6 months'
+        for_a_year: '1 year'
       subscription:
         statuses:
           pending_payment: Pending payment

--- a/config/locales/catarse_bootstrap/activerecord.pt.yml
+++ b/config/locales/catarse_bootstrap/activerecord.pt.yml
@@ -15,6 +15,11 @@ pt:
       page: 'Página'
       transparency_report: 'Relatório de Trasparência'
     attributes:
+      subscription/charge_options:
+        indefinite: 'Tempo indeterminado'
+        for_three_months: '3 meses'
+        for_six_months: '6 meses'
+        for_a_year: '1 ano'
       subscription:
         statuses:
           pending_payment: Pagamento pendente

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 RSpec.describe Subscription, type: :model do
 
+  describe "::ACCEPTED_CHARGE_OPTIONS" do
+    it "defines a constant containing the accepted charge options" do
+      expect(described_class.const_defined?(:ACCEPTED_CHARGE_OPTIONS)).to be_truthy
+    end
+  end
+
   describe "associations" do
     it{ is_expected.to belong_to :user }
     it{ is_expected.to belong_to :project }
@@ -45,6 +51,21 @@ RSpec.describe Subscription, type: :model do
       it "should be valid" do
         expect(permitted_payment_subscription).to be_valid
       end
+    end
+  end
+
+  describe ".accepted_charge_options" do
+    let(:charge_options) do
+      [
+        Subscription.human_attribute_name('charge_options.indefinite'),
+        Subscription.human_attribute_name('charge_options.for_three_months'),
+        Subscription.human_attribute_name('charge_options.for_six_months'),
+        Subscription.human_attribute_name('charge_options.for_a_year')
+      ]
+    end
+
+    it "should return an array matching all the ACCEPTED_CHARGE_OPTIONS's constant keys" do
+      expect(described_class.accepted_charge_options.keys).to match_array charge_options
     end
   end
 

--- a/spec/policies/subscription_policy_spec.rb
+++ b/spec/policies/subscription_policy_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe SubscriptionPolicy do
   subject{ SubscriptionPolicy }
 
-  let(:subscription) { create(:subscription) }
-  let(:user) { nil }
-  let(:policy) { subject.new(user, subscription) }
-
   shared_examples_for "create permissions" do
+    let(:subscription) { create(:subscription) }
+    let(:user) { nil }
+    let(:policy) { subject.new(user, subscription) }
+
     it "should deny the access if no user is logged" do
       is_expected.not_to permit(nil, subscription)
     end
@@ -31,5 +31,39 @@ RSpec.describe SubscriptionPolicy do
 
   permissions :cancel? do
     it_behaves_like "create permissions"
+  end
+
+  describe ".permitted_attributes" do
+    let(:subscription_permitted_attributes) do
+      [:plan_id, :project_id, :user_id, :payment_method, :charging_day, :charges]
+    end
+
+    subject { SubscriptionPolicy.new(user, subscription).permitted_attributes }
+
+    context "when user is nil" do
+      let(:user) { nil }
+      let(:subscription) { build(:subscription) }
+
+      it "returns an empty array" do
+        expect(subject).to eq []
+      end
+    end
+
+    context "when user is not nil" do
+      let(:user) { create(:user) }
+      let(:subscription) { build(:subscription, user: user) }
+
+      context "and user is the subscription owner" do
+        it "returns an array containing all the permitted subscription attributes" do
+          expect(subject).to match_array subscription_permitted_attributes
+        end
+      end
+
+      context "and user is admin" do
+        it "returns an array containing all the permitted subscription attributes" do
+          expect(subject).to match_array subscription_permitted_attributes
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
When the user creates a new subscription, he will have predefined values for the charges number of his subscription.  Avoiding subscriptions with only one charge, for example.

<img width="408" alt="screen shot 2017-01-11 at 5 41 11 pm" src="https://cloud.githubusercontent.com/assets/7783787/21865519/2f8d9b44-d825-11e6-89ff-ae0b3aef71c6.png">
