### PR TITLE
Created the 'update' action on Admin::ProjectsController

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -29,6 +29,20 @@ class Admin::ProjectsController < Channels::Admin::BaseController
     end
   end
 
+  def update
+    @project = Project.find(params[:id])
+
+    respond_to do |format|
+      if @project.update(project_params)
+        format.html { redirect_to [:admin, @project], flash: { notice: t('activerecord.project.update.success') } }
+        format.json { respond_with_bip(@project) }
+      else
+        format.html { redirect_to admin_projects_path, flash: { alert: @project.errors.full_messages.to_sentence } }
+        format.json { respond_with_bip(@project) }
+      end
+    end
+  end
+
   def move_project_to_channel
     MoveProjectToChannel.new(params[:project_id],params[:channel_id]).call
     redirect_to :back
@@ -67,6 +81,14 @@ class Admin::ProjectsController < Channels::Admin::BaseController
       @scoped_projects = @scoped_projects.by_channel(channel.id)
     end
     @scoped_projects
+  end
+
+  def permitted_params
+    params.permit(ProjectPolicy.new(current_user, @project).permitted_attributes)
+  end
+
+  def project_params
+    permitted_params[:project]
   end
 
   def collection

--- a/spec/controllers/admin/projects_controller_spec.rb
+++ b/spec/controllers/admin/projects_controller_spec.rb
@@ -17,6 +17,47 @@ RSpec.describe Admin::ProjectsController, type: :controller do
     it { expect(project.reload).to be_online }
   end
 
+  describe "PUT update" do
+    let(:project) { create(:project, recommended: false, name: 'old name') }
+
+    before { put :update, id: project, locale: :pt, project: project_new_attributes }
+
+    context "when all the attributes sent are valid" do
+      let(:project_new_attributes) do
+        {
+          name: 'new_name',
+          recommended: true
+        }
+      end
+
+      let(:success_message) { I18n.t('activerecord.project.update.success') }
+
+      it "returns an error flash message indicating the invalid attribute" do
+        expect(flash[:notice]).to match success_message
+      end
+
+      it { expect(project.reload).to have_attributes(project_new_attributes) }
+    end
+
+    context "when an invalid attribute value is sent" do
+      let(:project_new_attributes) do
+        {
+          name: '',
+          recommended: true
+        }
+      end
+
+      let(:error_message) do
+        I18n.t('activerecord.attributes.project.name') + " " +
+        I18n.t('activerecord.errors.models.project.attributes.name.blank')
+      end
+
+      it "returns an error flash message indicating the invalid attribute" do
+        expect(flash[:alert]).to match error_message
+      end
+    end
+  end
+
   describe 'PUT reject' do
     let(:project)       { create(:project, :in_analysis) }
     let(:reject_reason) { 'reject reason' }


### PR DESCRIPTION
This action was created because some views called by this controller use the `best_in_place` gem to update the project resource. But, there is no endpoint to process this kind of action, therefore, the update not occurs.