### PR TITLE
Created 'subscriptions:cancel_expired' and 'plans:update' rake tasks

### DIFF
--- a/app/services/pagarme/api.rb
+++ b/app/services/pagarme/api.rb
@@ -4,6 +4,12 @@ class Pagarme::API
   class InvalidAttributeError < StandardError; end
 
   class << self
+    def fetch_plans
+      PagarMe::Plan.all(1, 100)
+    rescue PagarMe::ConnectionError
+      raise_connection_error
+    end
+
     def find_plan(plan_id)
       PagarMe::Plan.find_by_id(plan_id)
     rescue PagarMe::ConnectionError

--- a/app/services/recurring_contribution/update_plans.rb
+++ b/app/services/recurring_contribution/update_plans.rb
@@ -25,7 +25,7 @@ class RecurringContribution::UpdatePlans
   end
 
   def pagarme_plans
-    PagarMe::Plan.all
+    Pagarme::API.fetch_plans
   end
 
   def plan_exist?(plan)

--- a/app/workers/recurring_contribution/update_plans_worker.rb
+++ b/app/workers/recurring_contribution/update_plans_worker.rb
@@ -1,0 +1,8 @@
+class RecurringContribution::UpdatePlansWorker
+  include Sidekiq::Worker
+  sidekiq_options retry: 2
+
+  def perform
+    RecurringContribution::UpdatePlans.call
+  end
+end

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -136,8 +136,22 @@ task :deliver_credits_more_than_10, [:percent] => :environment do |t, args|
 end
 
 namespace :recurring_contribution do
-  desc "Create pagarme's subscriptions scheduled for the current day"
-  task create_scheduled_pagarme_subscriptions: :environment do
-    RecurringContribution::ChargingSubscriptionWorker.perform_async
+  namespace :plans do
+    desc "Synchronize pagarme's plans on juntos' database"
+    task update: :environment do
+      RecurringContribution::UpdatePlansWorker.perform_async
+    end
+  end
+
+  namespace :subscriptions do
+    desc "Search for expired subscriptions and cancel them"
+    task cancel_expired: :environment do
+      RecurringContribution::CancelSubscriptionWorker.perform_async
+    end
+
+    desc "Create pagarme's subscriptions scheduled for the current day"
+    task charge_scheduled: :environment do
+      RecurringContribution::ChargingSubscriptionWorker.perform_async
+    end
   end
 end

--- a/spec/tasks/recurring_contribution/create_scheduled_pagarme_subscriptions_rake_spec.rb
+++ b/spec/tasks/recurring_contribution/create_scheduled_pagarme_subscriptions_rake_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe "Subscriptions" do
     Rake::Task.define_task(:environment)
   end
 
-  describe "recurring_contribution:create_scheduled_pagarme_subscriptions" do
+  describe "recurring_contribution:subscriptions:charge_scheduled" do
     let(:run_rake_task) do
-      Rake::Task['recurring_contribution:create_scheduled_pagarme_subscriptions'].reenable
-      Rake.application.invoke_task 'recurring_contribution:create_scheduled_pagarme_subscriptions'
+      Rake::Task['recurring_contribution:subscriptions:charge_scheduled'].reenable
+      Rake.application.invoke_task 'recurring_contribution:subscriptions:charge_scheduled'
     end
 
     it "calls the RecurringContribution::ChargingSubscriptionWorker" do

--- a/spec/workers/recurring_contribution/update_plans_worker_spec.rb
+++ b/spec/workers/recurring_contribution/update_plans_worker_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'sidekiq/testing'
+Sidekiq::Testing.fake!
+
+RSpec.describe RecurringContribution::UpdatePlansWorker do
+  subject { RecurringContribution::UpdatePlansWorker }
+
+  it "retries the job processing at most 2 times" do
+    expect(subject.get_sidekiq_options['retry']).to eq 2
+  end
+
+  describe "#perform_async" do
+    it "calls the RecurringContribution::UpdatePlans service" do
+      expect(RecurringContribution::UpdatePlans)
+        .to receive(:call)
+
+      Sidekiq::Testing.inline! do
+        subject.perform_async
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `recurring_contribution:plans:update` will synchronizes pagarme's plans on juntos' database and the `recurring_contribution:subscriptions:cancel_expired` will searches for expired subscriptions and cancel them.