### PR TITLE
Creating the Channels visibility feature

### DIFF
--- a/app/controllers/admin/channels_controller.rb
+++ b/app/controllers/admin/channels_controller.rb
@@ -20,7 +20,7 @@ class Admin::ChannelsController < Admin::BaseController
   private
 
   def channel_params
-    allow_attributes = %i(name email description recurring custom_submit_text permalink category_id)
+    allow_attributes = %i(name email description recurring custom_submit_text permalink visible category_id)
     params[:channel].permit(allow_attributes)
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -29,7 +29,7 @@ class ProjectsController < ApplicationController
           @featured_partners = SitePartner.featured
           @regular_partners = SitePartner.regular
           @site_partners = @featured_partners + @regular_partners
-          @channels = Channel.all.reject { |c| c.permalink == 'gastromotiva' || c.permalink == 'garupa' || c.permalink == 'descontinuado_garupa' }
+          @channels = Channel.visible
           @banners = HomeBanner.where.not(image: [nil, '']).order(numeric_order: :asc)
         end
       end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -33,8 +33,9 @@ class Channel < ActiveRecord::Base
   mount_uploader :image, ProfileUploader
   mount_uploader :email_header_image, ProfileUploader
 
-  scope :by_permalink, ->(p) { where("lower(channels.permalink) = lower(?)", p) }
-  scope :recurring, -> (value) { where(recurring: value) }
+  scope :by_permalink, -> (permalink) { where("lower(channels.permalink) = lower(?)", permalink) }
+  scope :recurring,    -> (value) { where(recurring: value) }
+  scope :visible,      -> { where(visible: true) }
 
   def self.find_by_permalink!(string)
     self.by_permalink(string).first!

--- a/app/views/juntos_bootstrap/admin/channels/_form.html.slim
+++ b/app/views/juntos_bootstrap/admin/channels/_form.html.slim
@@ -9,6 +9,7 @@
   .w-row
     .w-col.w-col-6
       = form.input :name, as: :string, required: true
+  .w-row
     .w-col.w-col-6
       = form.input :permalink, as: :string, required: true
   .w-row
@@ -16,16 +17,24 @@
       = form.input :category_id, as: :select, class: 'medium',
         collection: Category.order(:name_pt),
         prompt: t('simple_form.prompts.project.category')
-    .w-col.w-col-6
+  .w-row
+    .w-col.w-col-2
       = form.input :recurring, as: :select, collection: [:true, :false],
         prompt: false, required: true
+  .w-row
+    .w-row
+      .w-col.w-col-12
+        label.field-label = t('.project_visibility')
+    .w-row
+      .w-col.w-col-2
+        = form.input_field :visible, as: :select, collection: [:true, :false],
+          prompt: true
   .w-row
     .w-col.w-col-6
       = form.input :custom_submit_text, as: :string
   .w-row
-    .w-col.w-col-12
-      = form.input :description, as: :text, required: true
-
+    .w-col.w-col-6
+      = form.input :description, as: :text, required: true, input_html: { rows: 6 }
   .w-row
     .w-col.w-col-3.u-margintop-20.u-marginbottom-30
       = form.button :submit, class: 'btn btn-medium'

--- a/config/locales/catarse_bootstrap/simple_form.en.yml
+++ b/config/locales/catarse_bootstrap/simple_form.en.yml
@@ -5,6 +5,9 @@ en:
         recurring:
           "true": "Yes"
           "false": "No"
+        visible:
+          "true": "Yes"
+          "false": "No"
     collections:
       project:
         traffic_sources:

--- a/config/locales/catarse_bootstrap/simple_form.pt.yml
+++ b/config/locales/catarse_bootstrap/simple_form.pt.yml
@@ -5,6 +5,9 @@ pt:
         recurring:
           "true": "Sim"
           "false": "Não"
+        visible:
+          "true": "Sim"
+          "false": "Não"
     collections:
       project:
         traffic_sources:

--- a/config/locales/catarse_bootstrap/views/admin/channels.en.yml
+++ b/config/locales/catarse_bootstrap/views/admin/channels.en.yml
@@ -1,0 +1,5 @@
+en:
+  admin:
+    channels:
+      form:
+        project_visibility: "Should this project be visible on the channels' menu?"

--- a/config/locales/catarse_bootstrap/views/admin/channels.pt.yml
+++ b/config/locales/catarse_bootstrap/views/admin/channels.pt.yml
@@ -1,0 +1,5 @@
+pt:
+  admin:
+    channels:
+      form:
+        project_visibility: "Esse projeto ficará visível no menu de canais?"

--- a/db/migrate/20170123192632_add_visible_to_channels.rb
+++ b/db/migrate/20170123192632_add_visible_to_channels.rb
@@ -1,0 +1,5 @@
+class AddVisibleToChannels < ActiveRecord::Migration
+  def change
+    add_column :channels, :visible, :boolean, default: true
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -300,6 +300,14 @@ FactoryGirl.define do
     email "email+channel@foo.bar"
     description "Lorem Ipsum"
     sequence(:permalink) { |n| "#{n}-test-page" }
+
+    trait :visible do
+      visible true
+    end
+
+    trait :invisible do
+      visible false
+    end
   end
 
   factory :state do

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe Channel, type: :model do
     #it { is_expected.to have_and_belong_to_many :subscribers }
   end
 
+  describe ".visible" do
+    let(:visible_channels)  { create_list(:channel, 5, :visible) }
+    let(:invisible_channel) { create(:channel, :invisible) }
+
+    subject { described_class.visible }
+
+    it { is_expected.to match_array visible_channels }
+    it { is_expected.not_to include invisible_channel }
+  end
+
   describe ".by_permalink" do
     before do
       @c1 = create(:channel, permalink: 'foo')


### PR DESCRIPTION
Some channels should not be visible on the channels' menu on the root page of application after its creation. So, was added the `visible` attribute to the channels table, which will decide if a channel will be visible or not.