### PR TITLE
Create a service to fetch or create transaction from postback

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -1,6 +1,6 @@
 class TransactionsController < ApplicationController
   def update_status
-    transaction = Transaction.find_by(transaction_code: params[:id])
+    transaction = RecurringContribution::Transactions::FindOrCreate.process(params[:id])
     RecurringContribution::UpdateStatus.process(request, transaction)
     render nothing: true, status: :ok
   rescue RecurringContribution::UpdateStatus::InvalidRequestError

--- a/app/services/pagarme/api.rb
+++ b/app/services/pagarme/api.rb
@@ -26,6 +26,14 @@ class Pagarme::API
       raise ResourceNotFound
     end
 
+    def find_transaction(transaction_id)
+      PagarMe::Transaction.find_by_id(transaction_id)
+    rescue PagarMe::ConnectionError
+      raise_connection_error
+    rescue PagarMe::NotFound
+      raise ResourceNotFound
+    end
+
     def create_subscription(attributes)
       PagarMe::Subscription.create(attributes)
     rescue PagarMe::ConnectionError

--- a/app/services/recurring_contribution/transactions/find_or_create.rb
+++ b/app/services/recurring_contribution/transactions/find_or_create.rb
@@ -1,0 +1,30 @@
+class RecurringContribution::Transactions::FindOrCreate
+  attr_reader :transaction_code
+
+  def initialize(transaction_code)
+    @transaction_code = transaction_code
+  end
+
+  def self.process(transaction_code)
+    new(transaction_code).process
+  end
+
+  def process
+    Transaction.find_by(transaction_code: transaction_code) || create_transaction
+  end
+
+  private
+
+  def create_transaction
+    pagarme_transaction = Pagarme::API.find_transaction(transaction_code)
+    subscription = Subscription.find_by(subscription_code: pagarme_transaction.subscription_id)
+
+    Transaction.create({
+                         transaction_code: pagarme_transaction.id,
+                         status: pagarme_transaction.status,
+                         amount: pagarme_transaction.amount,
+                         payment_method: pagarme_transaction.payment_method,
+                         subscription: subscription
+                        })
+  end
+end

--- a/spec/services/recurring_contribution/transactions/find_or_create_spec.rb
+++ b/spec/services/recurring_contribution/transactions/find_or_create_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe RecurringContribution::Transactions::FindOrCreate do
+  describe ".process" do
+    subject { described_class.process(transaction_code) }
+
+    context "when the transaction is found" do
+      let(:transaction)      { create(:transaction) }
+      let(:transaction_code) { transaction.transaction_code }
+
+      it { is_expected.to eq(transaction) }
+    end
+
+    context "when the transaction is not found" do
+      let(:transaction_code)    { 1000 }
+      let(:subscription)        { create(:subscription) }
+      let(:transaction)         { build_transaction_mock(subscription.subscription_code) }
+      let(:created_transaction) { Transaction.find_by(transaction_code: transaction.id) }
+
+      before do
+        allow(Pagarme::API).to receive(:find_transaction).and_return(transaction)
+      end
+
+      it { is_expected.to eq(created_transaction) }
+
+      it "should have called the Transaction create method" do
+        expect(Transaction).to receive(:create).once.and_return(created_transaction)
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/support/recurring_contributions_helper.rb
+++ b/spec/support/recurring_contributions_helper.rb
@@ -15,11 +15,12 @@ module RecurringContributionsHelper
                    payment_methods: ['boleto', 'credit_card'])
   end
 
-  def build_transaction_mock
+  def build_transaction_mock(subscription_id = nil)
     double("Transaction", id: 10,
                           status: 'waiting_payment',
                           amount: '31000',
-                          payment_method: 'credit_card')
+                          payment_method: 'credit_card',
+                          subscription_id: subscription_id)
 
   end
 


### PR DESCRIPTION
When the `Pagarme's postback` response tries to update a transaction that is not on `Juntos' database`, it was crashing.
This pr implements a service to check if the transaction is persisted on `Juntos' database`. If so, then update. If not, create it from `Pagarme`.