### PR TITLE
Update the email template sent when a project is sent to in_analysis

### DIFF
--- a/app/views/juntos_bootstrap/user_notifier/mailer/in_analysis_project.html.slim
+++ b/app/views/juntos_bootstrap/user_notifier/mailer/in_analysis_project.html.slim
@@ -10,26 +10,26 @@ br
 | Nossa equipe acabou de receber o projeto  #{link_to project.name, project_link, target: '__blank'}
 br/
 br/
-| Durante os próximos 4 dias úteis, iremos analisar o rascunho de projeto que você nos enviou e te daremos uma resposta.
+| A nossa equipe irá analisar o rascunho do projeto que você nos enviou e te daremos uma resposta o mais breve possível.
 br
 br
-strong Você pode receber 3 tipos de resposta: 
+strong Você pode receber 3 tipos de resposta:
 br/
 br/
-strong Opção 1: 
-| Seu rascunho passou na análise, foi aceito e poderá ir ao ar! 
+strong Opção 1:
+| Seu rascunho passou na análise, foi aceito e poderá ir ao ar!
 br/
 | Agora é só marcarmos o dia e hora para estreiar seu projeto no site do Juntos.com.vc!
 br/
 br/
-strong Opção 2: 
-| Nos parece que o seu projeto tem muito ver com o #{company_name}, mas ainda precisa de alguns ajustes para ir para o ar. Vamos entrar em contato para entender possibilidades , sugerir coisas e tirar algumas dúvidas. 
+strong Opção 2:
+| Nos parece que o seu projeto tem muito ver com o #{company_name}, mas ainda precisa de alguns ajustes para ir para o ar. Vamos entrar em contato para entender possibilidades , sugerir coisas e tirar algumas dúvidas.
 br/
 br/
-strong Opção 3: 
-| Infelizmente, o rascunho de projeto que você enviou não se encaixa no perfil do site do #{company_name}. 
-| Enviaremos um email notificando a recusa. Sim, sabemos que recusas são sempre desagradáveis. Mas o lema aqui é 
-| "levanta, sacode a poeira e dá a volta por cima". Mas antes de sacudir qualquer poeira, 
+strong Opção 3:
+| Infelizmente, o rascunho de projeto que você enviou não se encaixa no perfil do site do #{company_name}.
+| Enviaremos um email notificando a recusa. Sim, sabemos que recusas são sempre desagradáveis. Mas o lema aqui é
+| "levanta, sacode a poeira e dá a volta por cima". Mas antes de sacudir qualquer poeira,
 | estude nossa #{link_to 'Central de Suporte', CatarseSettings[:support_forum], target: '__blank'}  para que você saiba tudo sobre nossos pré-requisitos para a construção do seu próximo projeto.
 br/
 br/


### PR DESCRIPTION
This pr removes the deadline for project to be analyzed from the email sent.
Now, the email's body just tells the project is going to be analyzed as soon as possible instead.