### PR TITLE
Remove alias that sends wrong template email when the contribution is canceled

### DIFF
--- a/app/observers/contribution_observer.rb
+++ b/app/observers/contribution_observer.rb
@@ -44,8 +44,6 @@ class ContributionObserver < ActiveRecord::Observer
     contribution.notify_to_backoffice :contribution_canceled_after_confirmed
     contribution.notify_to_contributor((contribution.slip_payment? ? :contribution_canceled_slip : :contribution_canceled))
   end
-  alias :from_waiting_confirmation_to_canceled :from_confirmed_to_canceled
-  alias :from_pending_to_canceled :from_confirmed_to_canceled
 
   private
   def do_direct_refund(contribution)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -215,7 +215,7 @@ FactoryGirl.define do
     end
 
     trait :slip_payment do
-      payment_choice 'DebitoBancario'
+      payment_choice 'boletobancario'
     end
 
     trait :confirmed do


### PR DESCRIPTION
When the contribution is canceled, the office is notified that a confirmed contribution was canceled, even when the contribution was pending or waiting_confirmation