### PR TITLE
Fixed Channels::ProfilesController update action

### DIFF
--- a/app/controllers/channels/profiles_controller.rb
+++ b/app/controllers/channels/profiles_controller.rb
@@ -13,14 +13,28 @@ class Channels::ProfilesController < Channels::BaseController
 
   def update
     authorize resource
-    update!
+
+    if resource.update(permitted_params)
+      flash[:notice] = t('success', scope: 'channels.profiles.update')
+      redirect_to channels_profile_path(resource)
+    else
+      flash[:alert] = resource.errors.full_messages.to_sentence
+      render :edit
+    end
   end
+
+  private
 
   def resource
     @profile ||= channel
   end
 
-  private
+  def permitted_params
+    params.require(:profile).permit(:ga_code, :name, :description, :original_image_url,
+                                    :original_email_header_image_url, :main_color,
+                                    :secondary_color, :facebook, :website, :how_it_works,
+                                    :terms, :contacts)
+  end
 
   def show_statistics
     @channel_statistics = ChannelStatisticsQuery.new(resource)

--- a/app/views/juntos_bootstrap/channels/profiles/edit.html.slim
+++ b/app/views/juntos_bootstrap/channels/profiles/edit.html.slim
@@ -3,7 +3,11 @@
 
 = render 'shared/header_channel'
 = content_for :title, @profile.name
+
 .w-container.u-margintop-40.u-marginbottom-40
+  .w-row
+    .w-col.w-col-12
+      = render partial: 'devise/shared/alert', locals: { resource: @profile }
   .w-row
     = simple_form_for @profile, as: 'profile', url: '/profile', html: { method: 'patch' }, class: 'channel-edit' do |form|
       - if current_user.admin

--- a/config/locales/catarse_bootstrap/views/channels/profiles/edit.en.yml
+++ b/config/locales/catarse_bootstrap/views/channels/profiles/edit.en.yml
@@ -1,0 +1,5 @@
+en:
+  channels:
+    profiles:
+      update:
+        success: 'Channel has been updated'

--- a/config/locales/catarse_bootstrap/views/channels/profiles/edit.pt.yml
+++ b/config/locales/catarse_bootstrap/views/channels/profiles/edit.pt.yml
@@ -1,0 +1,5 @@
+pt:
+  channels:
+    profiles:
+      update:
+        success: 'As informações foram atualizadas'

--- a/spec/controllers/channels/profiles_controller_spec.rb
+++ b/spec/controllers/channels/profiles_controller_spec.rb
@@ -10,4 +10,49 @@ RSpec.describe Channels::ProfilesController, type: :controller do
       expect(response).to be_success
     end
   end
+
+  describe "PUT update" do
+    let (:user)    { create(:user, admin: true) }
+    let (:channel) { create(:channel, users: [user]) }
+
+    before do
+      allow(request).to receive(:subdomain).and_return(channel.permalink)
+      sign_in user
+      put :update, id: channel.permalink, locale: 'pt', profile: params
+    end
+
+    context "when invalid params are sent" do
+      let(:params) { { name: '' } }
+      let(:error_message) do
+        I18n.t('activerecord.attributes.channel.name') + ' ' + \
+        I18n.t('activerecord.errors.messages.blank')
+      end
+
+      it "renders the edit view" do
+        expect(response).to render_template(:edit)
+      end
+
+      it "returns an error flash message" do
+        expect(flash[:alert]).to match error_message
+      end
+    end
+
+    context "when all params sent are valid" do
+      let(:params) { { name: 'Foo Channel', ga_code: '<script></script>' } }
+      let(:updated_channel) { Channel.find(channel.id) }
+
+      it "updates the channel" do
+        expect(updated_channel)
+          .to have_attributes(name: 'Foo Channel', ga_code: '<script></script>')
+      end
+
+      it "redirects to channel's profile view" do
+        expect(response).to redirect_to channels_profile_path(channel)
+      end
+
+      it "returns a success flash message" do
+        expect(flash[:notice]).to match I18n.t('success', scope: 'channels.profiles.update')
+      end
+    end
+  end
 end


### PR DESCRIPTION
The inherited_resource's gem `update!` method was removed and replaced by a straight call of the active record's `update` method.