### PR TITLE
Send payer name and payer email when contributing

### DIFF
--- a/app/assets/javascripts/app/review_form.js
+++ b/app/assets/javascripts/app/review_form.js
@@ -253,8 +253,8 @@ App.addChild('ReviewForm', _.extend({
     var contribution_data = {
       anonymous: this.$('#contribution_anonymous').is(':checked'),
       country_code: this.$('#contribution_country_code').val(),
-      payer_name: this.$('#contribution_full_name').val(),
-      payer_email: this.$('#contribution_email').val(),
+      payer_name: this.$('#contribution_payer_name').val(),
+      payer_email: this.$('#contribution_payer_email').val(),
       payer_document: this.$('#contribution_payer_document').val(),
       address_street: this.$('#contribution_address_street').val(),
       address_number: this.$('#contribution_address_number').val(),


### PR DESCRIPTION
The payer name and payer email going to MoIP as parameters were got from `current_user`, even if the user set a different one when filling the contribution payment data form.