### PR TITLE
Disable edit recurring channel

### DIFF
--- a/app/controllers/admin/channels_controller.rb
+++ b/app/controllers/admin/channels_controller.rb
@@ -13,6 +13,7 @@ class Admin::ChannelsController < Admin::BaseController
     if @channel.update(channel_params)
       redirect_to admin_channels_path
     else
+      flash[:alert] = @channel.errors.full_messages.to_sentence
       render 'new'
     end
   end

--- a/app/views/juntos_bootstrap/admin/channels/_form.html.slim
+++ b/app/views/juntos_bootstrap/admin/channels/_form.html.slim
@@ -20,7 +20,7 @@
   .w-row
     .w-col.w-col-2
       = form.input :recurring, as: :select, collection: [:true, :false],
-        prompt: false, required: true
+        prompt: false, required: true, input_html: { disabled: !@channel.updatable_recurring? }
   .w-row
     .w-row
       .w-col.w-col-12

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -23,6 +23,10 @@ en:
         title: 'New channel'
       edit:
         title: 'Edit channel'
+      messages:
+        recurring:
+          error:
+            update: 'Cannot update the recurrence for a channel that has associated projects.'
     pages:
       index:
         menu: 'Admin Who we are'

--- a/config/locales/admin.pt.yml
+++ b/config/locales/admin.pt.yml
@@ -19,6 +19,10 @@ pt:
         title: 'Novo canal'
       edit:
         title: 'Editar canal'
+      messages:
+        recurring:
+          error:
+            update: 'Não é possível atualizar a recorrência de um canal que possui projetos associados.'
     pages:
       index:
         menu: 'Admin Quem Somos'

--- a/spec/controllers/admin/channels_controller_spec.rb
+++ b/spec/controllers/admin/channels_controller_spec.rb
@@ -15,22 +15,57 @@ RSpec.describe Admin::ChannelsController, type: :controller do
     let(:channel)         { create(:channel, recurring: true, custom_submit_text: 'custom_text') }
     let(:updated_channel) { Channel.find(channel.id) }
     let(:category)        { create(:category) }
+    let(:updated_channel) { Channel.find channel.id }
     let(:channel_attributes) do
       {
-        category_id: category.id,
-        name: 'new_name',
-        email: 'email_channel_123@foo.bar',
-        description: 'Foo description bar',
-        permalink: 'foo_permalink_test_bar',
-        recurring: false,
-        custom_submit_text: 'update_custom_text'
+        category_id:        category.id,
+        custom_submit_text: 'update_custom_text',
+        description:        'Foo description bar',
+        email:              'email_channel_123@foo.bar',
+        name:               'new_name',
+        permalink:          'foo_permalink_test_bar',
+        recurring:          false,
+        visible:            false
       }
     end
 
-    before do
-      put(:update, id: channel.id, channel: channel_attributes, locale: :pt)
+    context "when the channel is recurring" do
+      let(:channel) { create(:channel, :recurring) }
+      let(:error_message) { I18n.t('admin.channels.messages.recurring.error.update') }
+
+      context "and it has projects associated" do
+        before do
+          create(:project, channels: [channel])
+
+          put(:update, id: channel.id, channel: channel_attributes, locale: :pt)
+        end
+
+        it "does not update the channel" do
+          expect(flash[:alert]).to match(error_message)
+        end
+      end
+
+      context "and it has no projects associated" do
+        before do
+          put(:update, id: channel.id, channel: channel_attributes, locale: :pt)
+        end
+
+        it "updates all the attributes" do
+          expect(updated_channel).to have_attributes(channel_attributes)
+        end
+      end
     end
 
-    it { expect(updated_channel).to have_attributes(channel_attributes) }
+    context "when the channel is not recurring" do
+      let(:channel) { create(:channel, :non_recurring) }
+
+      before do
+        put(:update, id: channel.id, channel: channel_attributes, locale: :pt)
+      end
+
+      it "updates all the attributes" do
+        expect(updated_channel).to have_attributes(channel_attributes)
+      end
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -308,6 +308,14 @@ FactoryGirl.define do
     trait :invisible do
       visible false
     end
+
+    trait :recurring do
+      recurring true
+    end
+
+    trait :non_recurring do
+      recurring false
+    end
   end
 
   factory :state do

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -64,6 +64,19 @@ RSpec.describe Channel, type: :model do
     end
   end
 
+  describe "#updatable_recurring?" do
+    let(:channel) { create(:channel) }
+
+    context "when the channel has projects associated" do
+      before { create(:project, channels: [channel]) }
+
+      it { expect(channel.reload).not_to be_updatable_recurring }
+    end
+
+    context "when the channel has no projects associated" do
+      it { expect(channel).to be_updatable_recurring }
+    end
+  end
 
   describe "#has_subscriber?" do
     let(:channel) { create(:channel) }


### PR DESCRIPTION
When updating a channel, it should not allow to set recurring to false if the channel is recurring and it has projects associated.