### PR TITLE
Updated deploy rake task

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -33,7 +33,7 @@ namespace :deploy do
 
   task :restart do
     puts 'Restarting app servers ...'
-    heroku_cmd "heroku restart --app #{APP}"
+    heroku_cmd "restart --app #{APP}"
   end
 
   task :tag do


### PR DESCRIPTION
The duplicated heroku keyword was removed from the restart app subtask.