### PR TITLE
Allow project owner to be able to edit name in 'basics' tab and everything in 'project' tab

### DIFF
--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -73,8 +73,12 @@ class ProjectPolicy < ApplicationPolicy
   end
 
   def project_attributes_for_owner
-    { project: [
-        :video_url, :about, :thank_you, :uploaded_image,
+    {
+      project: [
+        :name, :video_url, :about, :thank_you, :uploaded_image,
+        :uploaded_cover_image, :headline, :original_uploaded_image,
+        :original_uploaded_cover_image,
+        project_images_attributes: [:original_image_url, :caption, :id, :_destroy],
         project_partners_attributes: [:original_image_url, :link, :id, :_destroy],
         posts_attributes: [:title, :comment, :exclusive, :user_id]
       ]

--- a/app/views/juntos_bootstrap/projects/_dashboard_project.html.slim
+++ b/app/views/juntos_bootstrap/projects/_dashboard_project.html.slim
@@ -134,7 +134,7 @@
                   max_file_size: 5.megabytes, data: {s3_uploader: true},
                   key: "uploads/project/uploaded_image/#{@project.id}/${filename}" do
                     = file_field_tag :file, id: 'uploaded-image-upload', class: 'w-input text-field',
-                      data: {url: s3_uploader_url}, disabled: @project.editable_field?
+                      data: {url: s3_uploader_url}
 
                 = hidden_field_tag 'project[original_uploaded_image]', nil,
                   data: {image_field: true}
@@ -147,7 +147,7 @@
                   max_file_size: 5.megabytes, data: {s3_uploader: true},
                   key: "uploads/project/uploaded_cover_image/#{@project.id}/${filename}" do
                     = file_field_tag :file, id: 'uploaded-cover-image-upload',  class: 'w-input text-field',
-                      data: {url: s3_uploader_url}, disabled: @project.editable_field?
+                      data: {url: s3_uploader_url}
 
                 = hidden_field_tag 'project[original_uploaded_cover_image]', nil,
                   data: {image_field: true}
@@ -156,7 +156,7 @@
               label.field-label.fontweight-semibold= t('.headline')
               label.field-label.fontsize-smallest.fontcolor-secondary= t('.headline_hint')
             .w-col.w-col-7
-              = form.input_field :headline, as: :text, class: 'positive', disabled: @project.editable_field?
+              = form.input_field :headline, as: :text, class: 'positive'
         .w-col.w-col-4
           = render @project
   .divider

--- a/app/views/juntos_bootstrap/projects/_project_basics.html.slim
+++ b/app/views/juntos_bootstrap/projects/_project_basics.html.slim
@@ -42,7 +42,7 @@
                   label.field-label.fontweight-semibold for="name-8"= t('.name')
                   label.field-label.fontsize-smallest.fontcolor-secondary for="name-8"=t('.name_label')
                 .w-col.w-col-7
-                  = form.input_field :name, as: :string, class: 'positive', disabled: @project.editable_field?
+                  = form.input_field :name, as: :string, class: 'positive'
                     .text-error.fontsize-smallest
                       span.fa.fa-exclamation-triangle .
                       | \&nbsp;This is some text inside of a div block.
@@ -103,5 +103,5 @@
         .w-row
           .w-col.w-col-4
           .w-col.w-col-4
-            = form.button :submit, t('.form.submit'), class:'btn btn-large', disabled: @project.editable_field?
+            = form.button :submit, t('.form.submit'), class:'btn btn-large'
           .w-col.w-col-4

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -101,21 +101,13 @@ RSpec.describe ProjectsController, type: :controller do
 
     shared_examples_for "protected project" do
       let(:project_attributes) do
-        {
-          headline:  'updated_headline',
-          name:      'updated_name',
-          permalink: 'updated_permalink'
-        }
+        { permalink: 'updated_permalink' }
       end
 
       before do
         put :update, id: project.id, project: project_attributes, locale: :pt
         project.reload
       end
-
-      it { expect(project.headline).not_to eq('updated_headline') }
-
-      it { expect(project.name).not_to eq('updated_name') }
 
       it { expect(project.permalink).not_to eq('updated_permalink') }
     end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -105,7 +105,10 @@ RSpec.describe ProjectPolicy do
     end
     let(:project_owner_allowed_attributes) do
       [
-        :video_url, :about, :thank_you, :uploaded_image,
+        :name, :video_url, :about, :thank_you, :uploaded_image,
+        :uploaded_cover_image, :headline, :original_uploaded_image,
+        :original_uploaded_cover_image,
+        project_images_attributes: [:original_image_url, :caption, :id, :_destroy],
         project_partners_attributes: [:original_image_url, :link, :id, :_destroy],
         posts_attributes: [:title, :comment, :exclusive, :user_id]
       ]


### PR DESCRIPTION
If the current user is a project owner and the project went online already, it should be able to edit everything from 'projects' tab and the name only from 'basics' tab.