### PR TITLE
Add `word-wrap: normal;` to the mobile project progress description

### DIFF
--- a/app/assets/stylesheets/juntos_bootstrap/_main.scss
+++ b/app/assets/stylesheets/juntos_bootstrap/_main.scss
@@ -4067,6 +4067,7 @@ div .w-container .w-row .nav-tabs .mobile-tab.selected{
   position: relative;
   top: 50%;
   transform: translateY(-50%);
+  word-wrap: normal;
 }
 .btn-select-reward-mobile{
   background-color: #0c556e;


### PR DESCRIPTION
The problem is that on the project-progress-description div, it was set word-wrap to allow unbreakable words to be broken. It was breaking a number that should not be broken.