### PR TITLE
Ignore optional authorization documents only on User's model

### DIFF
--- a/app/models/authorization_document.rb
+++ b/app/models/authorization_document.rb
@@ -26,6 +26,8 @@ class AuthorizationDocument < ActiveRecord::Base
                   :manager_id
                 ]
 
+  protected
+
   def attachment_present
     assign_document_error(category_i18n) unless attachment.url.present?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,7 +68,7 @@ class User < ActiveRecord::Base
   has_many   :category_followers
   has_many   :categories, through: :category_followers
   has_many   :recurring_contributions, class_name: 'Subscription'
-  has_many   :authorization_documents, as: :authable
+  has_many   :authorization_documents, as: :authable, class_name: 'UserAuthorizationDocument'
   has_and_belongs_to_many :recommended_projects, join_table: :recommendations, class_name: 'Project'
   has_and_belongs_to_many :subscriptions, join_table: :channels_subscribers, class_name: 'Channel'
 

--- a/app/models/user_authorization_document.rb
+++ b/app/models/user_authorization_document.rb
@@ -1,0 +1,15 @@
+class UserAuthorizationDocument < AuthorizationDocument
+  OPTIONAL_DOCUMENTS = %i(certificates last_year_activities_report organization_current_plan)
+
+  def attachment_present
+    assign_document_error(category_i18n) if invalid_document?
+  end
+
+  def invalid_document?
+    document_required? && attachment.url.blank?
+  end
+
+  def document_required?
+    OPTIONAL_DOCUMENTS.exclude?(category.to_sym)
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -444,6 +444,12 @@ FactoryGirl.define do
     end
   end
 
+  factory :user_authorization_document do
+    expires_at Date.current
+    category :uncategorized
+    association :attachment
+  end
+
   factory :authorization_document do
     expires_at Date.current
     category :uncategorized

--- a/spec/models/user_authorization_document_spec.rb
+++ b/spec/models/user_authorization_document_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe UserAuthorizationDocument, type: :model do
+  describe "validations" do
+    describe "attachment validation" do
+      let(:user) { create(:user) }
+      let(:user_authorization_document) do
+        build(:user_authorization_document,
+          authable: user,
+          category: category,
+          attachment: attachment
+        )
+      end
+
+      subject { user_authorization_document }
+
+      context "when the category's document requires an attachment" do
+        let(:category) { :cnpj_card }
+
+        context "and the attachment is present" do
+          let(:attachment) { build(:attachment, url: 'http://valid.com') }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "and the attachment is empty" do
+          let(:attachment) { build(:attachment, url: '') }
+
+          it { is_expected.to be_invalid }
+        end
+      end
+
+      context "when the category's document does not require an attachment" do
+        let(:category) { :certificates }
+
+        context "and the attachment is present" do
+          let(:attachment) { build(:attachment, url: 'http://valid.com') }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "and the attachment is empty" do
+          let(:attachment) { build(:attachment, url: 'http://valid.com') }
+
+          it { is_expected.to be_valid }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The user model has a special condition for the authorization documents' validation. Three of the document categories needed by user are optional, so, if a save/update request is sent to user with empty attachment urls for these categories the operation must be valid.