### PR TITLE
Showing the user documents on project profile's documents tab

### DIFF
--- a/app/assets/javascripts/app/form/remote_requests.js
+++ b/app/assets/javascripts/app/form/remote_requests.js
@@ -27,4 +27,17 @@ var RemoteRequestsForm = function (el) {
   this.appendErrorMessage = function (message) {
     this.$errorCard.find('.message').empty().append(message);
   };
+
+  this.showForm = function (e) {
+    var targetForm = $(e.target).data('target');
+    var $form = $(targetForm);
+
+    $form.closest('.content').removeClass('w-hidden');
+  };
+
+  this.hideForm = function (e) {
+    var $form = $(e.target).closest('form');
+
+    $form.closest('.content').addClass('w-hidden');
+  };
 };

--- a/app/assets/javascripts/app/project/authorization_documents_management.js
+++ b/app/assets/javascripts/app/project/authorization_documents_management.js
@@ -1,0 +1,10 @@
+App.addChild('AuthorizationDocumentsManagement', _.extend({
+  el: '.authorization-documents-list',
+
+  events: {
+    'click #open-form':  'showForm',
+    'click #close-form': 'hideForm',
+    'ajax:success':      'onAjaxSuccess',
+    'ajax:error':        'onAjaxError',
+  },
+}, new RemoteRequestsForm($('#user-authorization-documents-form'))));

--- a/app/assets/javascripts/app/project/bank_account_management.js
+++ b/app/assets/javascripts/app/project/bank_account_management.js
@@ -2,8 +2,8 @@ App.addChild('BankAccountAssociate', _.extend({
   el: '#bank-account-associate',
 
   events: {
-    'click #new-account': 'showNewBankAccountForm',
-    'click #close-form':  'hideNewBankAccountForm',
+    'click #new-account': 'showForm',
+    'click #close-form':  'hideForm',
     'ajax:success':       'onAjaxPostSuccess',
     'ajax:error':         'onAjaxError',
   },
@@ -27,14 +27,6 @@ App.addChild('BankAccountAssociate', _.extend({
       this.$associationButton.prop('disabled', false);
       this.hideNewBankAccountForm();
     }
-  },
-
-  showNewBankAccountForm: function () {
-    this.$bankAccountForm.closest('.content').removeClass('w-hidden');
-  },
-
-  hideNewBankAccountForm: function () {
-    this.$bankAccountForm.closest('.content').addClass('w-hidden');
   },
 
   appendNewAccount: function (bankAccount) {

--- a/app/assets/javascripts/app/user/authorization_documents_form.js
+++ b/app/assets/javascripts/app/user/authorization_documents_form.js
@@ -1,8 +1,0 @@
-App.addChild('UserAuthorizationDocumentsForm', _.extend({
-  el: '#user-authorization-documents-form',
-
-  events: {
-    'ajax:success': 'onAjaxSuccess',
-    'ajax:error':   'onAjaxError',
-  },
-}, new RemoteRequestsForm($('#user-authorization-documents-form'))));

--- a/app/assets/stylesheets/juntos_bootstrap/_main.scss
+++ b/app/assets/stylesheets/juntos_bootstrap/_main.scss
@@ -283,13 +283,12 @@ p {
   background-color: white;
 }
 .link {
-  -webkit-transition: all 500ms ease;
-  -o-transition: all 500ms ease;
-  transition: all 500ms ease;
-  color: #f69219;
-  font-size: 16px;
+  color: $tree-poppy;
+  cursor: pointer;
+  font-size: rem-calc($base-font-size);
   font-weight: 600;
   text-decoration: none;
+  transition: all 500ms ease;
 }
 .link:hover {
   text-decoration: underline;
@@ -426,6 +425,22 @@ p {
     display: block;
     font-size: 12px;
     font-weight: normal;
+  }
+}
+
+.authorization-documents-list {
+  .documents {
+    .category {
+      display: block;
+      max-width: rem-calc(380);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .not-sent {
+      color: $tree-poppy;
+    }
   }
 }
 

--- a/app/assets/stylesheets/juntos_bootstrap/catarse.css.scss
+++ b/app/assets/stylesheets/juntos_bootstrap/catarse.css.scss
@@ -14,6 +14,7 @@
 @import 'juntos_bootstrap/components/forms';
 @import 'juntos_bootstrap/components/buttons';
 @import 'juntos_bootstrap/components/tables';
+@import 'juntos_bootstrap/components/links';
 
 @import 'juntos_bootstrap/containers/dashboards';
 

--- a/app/assets/stylesheets/juntos_bootstrap/components/_links.scss
+++ b/app/assets/stylesheets/juntos_bootstrap/components/_links.scss
@@ -1,0 +1,5 @@
+.link {
+  &.default {
+    color: $royal-blue;
+  }
+}

--- a/app/assets/stylesheets/juntos_bootstrap/components/_tables.scss
+++ b/app/assets/stylesheets/juntos_bootstrap/components/_tables.scss
@@ -1,4 +1,4 @@
-.bank-accounts-table {
+.standard-table {
   width: 100%;
 
   th,

--- a/app/assets/stylesheets/juntos_bootstrap/containers/_dashboards.scss
+++ b/app/assets/stylesheets/juntos_bootstrap/containers/_dashboards.scss
@@ -1,16 +1,12 @@
 .dashboard {
   position: relative;
 
-  &.user-authorization-documents {
-    background-color: $border-gray;
-    border: .3px solid $border-gray;
-    border-radius: 4px;
-
+  .dashboard-menu {
     .link {
       border-bottom: .3px solid $border-strong;
       color: $trout;
-      opacity: .6;
       display: block;
+      opacity: .6;
       padding: rem-calc(10);
     }
 
@@ -20,10 +16,16 @@
       opacity: 1;
       text-decoration: none;
     }
+  }
+
+  &.user-authorization-documents {
+    background-color: $border-gray;
+    border: .9px solid $border-gray;
+    border-radius: 4px;
 
     .dashboard-content {
       background-color: $white;
-      border-left: .3px solid $border-gray;
+      border-left: .9px solid $border-gray;
     }
   }
 }

--- a/app/decorators/authorization_document_decorator.rb
+++ b/app/decorators/authorization_document_decorator.rb
@@ -1,0 +1,22 @@
+class AuthorizationDocumentDecorator < Draper::Decorator
+  delegate_all
+
+  def visualization
+    return document_link if source.uploaded?
+
+    not_sent_message
+  end
+
+  private
+
+  def document_link
+    h.content_tag(:a, href: source.attachment.url, class: 'link default', target: '_blank') do
+      h.content_tag(:span, I18n.t('users.required_documents.list.sent')) +
+      h.content_tag(:i, nil, class: 'fa fa-eye u-marginleft-5')
+    end
+  end
+
+  def not_sent_message
+    h.content_tag(:span, I18n.t('users.required_documents.list.not_sent'), class: 'not-sent bold')
+  end
+end

--- a/app/models/authorization_document.rb
+++ b/app/models/authorization_document.rb
@@ -26,10 +26,14 @@ class AuthorizationDocument < ActiveRecord::Base
                   :manager_id
                 ]
 
+  def uploaded?
+    attachment && attachment.url.present?
+  end
+
   protected
 
   def attachment_present
-    assign_document_error(category_i18n) unless attachment.url.present?
+    assign_document_error(category_i18n) unless uploaded?
   end
 
   private

--- a/app/view_objects/project_documentation_view_object.rb
+++ b/app/view_objects/project_documentation_view_object.rb
@@ -20,6 +20,10 @@ class ProjectDocumentationViewObject
     user.bank_accounts.decorate
   end
 
+  def user_authorization_documents
+    decorate_documents(user.authorization_documents)
+  end
+
   def user_without_bank_accounts?
     user.bank_accounts.empty?
   end
@@ -39,5 +43,9 @@ class ProjectDocumentationViewObject
     end
 
     resource
+  end
+
+  def decorate_documents(documents)
+    AuthorizationDocumentDecorator.decorate_collection(documents)
   end
 end

--- a/app/views/juntos_bootstrap/projects/_dashboard_documents.html.slim
+++ b/app/views/juntos_bootstrap/projects/_dashboard_documents.html.slim
@@ -11,7 +11,7 @@
                   span.bold = t('projects.show.dashboard_nav.documents')
             .w-row
               .w-col.w-col-12
-                = link_to '#bank-accounts', id: 'bank-accounts', class: 'link' , data: { target: '#project_bank_info' } do
+                = link_to '#bank-accounts', id: 'bank-accounts', class: 'link' , data: { target: '#project-bank-info' } do
                   span
                     span.bold = t('projects.show.dashboard_nav.bank_info')
     .dashboard-content.w-col.w-col-9
@@ -21,8 +21,8 @@
             .w-row
               .w-col.w-col-12
                 #project_authorization_documents.content.w-hidden
-                  = render "projects/required_documents/list", user: project_documentation.user
+                  = render "projects/required_documents/list", project_documentation: project_documentation
             .w-row
               .w-col.w-col-12
-                #project_bank_info.content.w-hidden
+                #project-bank-info.content.w-hidden
                   = render "projects/bank_accounts/associate", project_documentation: project_documentation

--- a/app/views/juntos_bootstrap/projects/bank_accounts/_associate.html.slim
+++ b/app/views/juntos_bootstrap/projects/bank_accounts/_associate.html.slim
@@ -1,10 +1,10 @@
  #bank-account-associate
   .w-row
     .w-row
-      .w-col.w-col-12.u-text-center
+      .w-col.w-col-11.u-text-center
         h3 = t('users.bank_accounts.new.title')
     .w-row
-      .w-col.w-col-12.u-text-center
+      .w-col.w-col-11.u-text-center
         p = t('users.bank_accounts.new.subtitle')
 
   .w-row
@@ -27,7 +27,7 @@
                     - if project_documentation.user_without_bank_accounts?
                       span.u-marginbottom-10.font-tiny.label-helper = t('users.bank_accounts.management.notification.no_accounts_registered')
                   .w-col.w-col-1.u-marginleft-5
-                    a.btn.btn-small.btn-secondary#new-account
+                    a.btn.btn-small.btn-secondary#new-account data-target='#user-bank-account-form'
                       i.fa.fa-plus.new-account
                 .w-row
                   .w-col.w-col-4

--- a/app/views/juntos_bootstrap/projects/required_documents/_list.html.slim
+++ b/app/views/juntos_bootstrap/projects/required_documents/_list.html.slim
@@ -1,13 +1,28 @@
-#authorization-documents-list
+.authorization-documents-list
   .w-row
     .w-row
-      .w-col.w-col-12.u-text-center
+      .w-col.w-col-11.u-text-center
         h3 = t('users.required_documents.list.title')
     .w-row
-      .w-col.w-col-12.u-text-center
+      .w-col.w-col-11.u-text-center
         p = t('users.required_documents.list.subtitle')
-
+  .w-row.u-marginbottom-20
     .w-row
-      .w-col.w-col-12
-        .form
-          = render '/users/authorization_documents/form', user: user
+      table.standard-table.documents
+        thead
+          th= t('users.required_documents.list.documents')
+          th= t('users.required_documents.list.status')
+          - project_documentation.user_authorization_documents.each do |document|
+            tr
+              td
+                span.category = document.category_i18n
+              td = document.visualization
+  .w-row.u-marginbottom-20
+    .w-col.w-col-12
+      a.link.font-tiny#open-form data-target='#user-authorization-documents-form'
+        = t('users.required_documents.list.update')
+
+  .w-row.w-hidden.content
+    .w-col.w-col-12
+      .form
+        = render '/users/authorization_documents/form', user: project_documentation.user

--- a/app/views/juntos_bootstrap/projects/show.html.slim
+++ b/app/views/juntos_bootstrap/projects/show.html.slim
@@ -112,7 +112,7 @@ nav.project-nav.w-hidden-main.w-hidden-medium
           span.u-marginleft-10 = t('.dashboard_nav.rewards')
 
       - if @project.recurring?
-        = link_to '#dashboard_project_documents', id: 'dashboard_project_documents_link', class: 'dashboard-nav-link ' , data: {target: '#project_bank_info'} do
+        = link_to '#dashboard_project_documents', id: 'dashboard_project_documents_link', class: 'dashboard-nav-link ' , data: {target: '#project_documentation'} do
           span.fa.fa-check-circle
             span.u-marginleft-10 = t('.dashboard_nav.required_documentation')
         = link_to '#dashboard_project_plans', id: 'dashboard_project_plans_link', class: 'dashboard-nav-link' , data: {target: '#dashboard_project_plans'} do
@@ -166,7 +166,7 @@ nav.project-nav.w-hidden-main.w-hidden-medium
       #dashboard_rewards.content.w-hidden
         = render 'dashboard_reward'
       - if @project.recurring?
-        #project_bank_info.content.w-hidden
+        #project_documentation.content.w-hidden
           = render "dashboard_documents", project_documentation: @project_documentation
         #dashboard_project_plans.content.w-hidden
           = render 'projects/plans/dashboard_project_plans', plans: @plans

--- a/app/views/users/authorization_documents/_form.html.slim
+++ b/app/views/users/authorization_documents/_form.html.slim
@@ -1,3 +1,7 @@
+.w-row
+  .w-col.w-col-12
+    h3 = t('users.authorization_documents.new.title')
+
 = simple_form_for user, remote: true,
                   html: { id: 'user-authorization-documents-form', class: 'w-form authorization_documents association-form' } do |form|
   .section
@@ -33,6 +37,8 @@
               .w-row
                 .w-col.w-col-4
                   = form.button :submit, t('users.authorization_documents.form.submit'), class:'btn btn-small'
+                .w-col.w-col-4.u-marginleft-5
+                  a.btn.btn-small.btn-secondary#close-form = t('users.bank_accounts.form.cancel')
                 .w-col.w-col-4
                   = render 'shared/form_notifications', success: t('users.authorization_documents.new.success'),
                     fail: t('users.bank_accounts.new.success')

--- a/config/locales/catarse_bootstrap/views/users/documents/list.en.yml
+++ b/config/locales/catarse_bootstrap/views/users/documents/list.en.yml
@@ -4,3 +4,8 @@ en:
       list:
         title: 'Required documentation'
         subtitle: 'Before your project be online, we need some documents about your organization:'
+        update: '+ Update documentation'
+        documentation_status: 'Document'
+        status: 'Status'
+        sent: 'Sent'
+        not_sent: 'Not sent'

--- a/config/locales/catarse_bootstrap/views/users/documents/list.pt.yml
+++ b/config/locales/catarse_bootstrap/views/users/documents/list.pt.yml
@@ -4,3 +4,8 @@ pt:
       list:
         title: 'Documentação necessária'
         subtitle: 'Antes do seu projeto ficar online, precisamos de alguns documentos sobre sua organização:'
+        update: '+ Atualizar documentação'
+        documents: 'Documento'
+        status: 'Status'
+        sent: 'Enviado'
+        not_sent: 'Não enviado'

--- a/config/locales/catarse_bootstrap/views/users/documents/new.en.yml
+++ b/config/locales/catarse_bootstrap/views/users/documents/new.en.yml
@@ -2,6 +2,7 @@ en:
   users:
     authorization_documents:
       new:
+        title: "Attach documents"
         success: "The documents are sent"
       form:
-        submit: "Send"
+        submit: "Update"

--- a/config/locales/catarse_bootstrap/views/users/documents/new.pt.yml
+++ b/config/locales/catarse_bootstrap/views/users/documents/new.pt.yml
@@ -2,6 +2,7 @@ pt:
   users:
     authorization_documents:
       new:
+        title: "Anexar documentos"
         success: "Documentos enviados"
       form:
-        submit: "Enviar"
+        submit: "Atualizar"

--- a/spec/decorators/authorization_document_decorator_spec.rb
+++ b/spec/decorators/authorization_document_decorator_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe AuthorizationDocumentDecorator do
+  describe ".visualization" do
+    let(:authorization_document) { build(:authorization_document, attachment: attachment).decorate }
+
+    subject { authorization_document.visualization}
+
+    context "when the document has an attachment" do
+      let(:attachment) { build(:attachment) }
+      let(:view_document_message) { I18n.t('users.required_documents.list.sent') }
+
+      it "returns a link tag for the document visualization" do
+        expect(subject).to have_tag('a', text: view_document_message)
+      end
+    end
+
+    context "when the document does not have an attachment" do
+      let(:attachment) { build(:attachment, :with_empty_url) }
+      let(:not_sent_message) { I18n.t('users.required_documents.list.not_sent') }
+
+      it "returns not sent message" do
+        expect(subject).to have_tag('span', text: not_sent_message)
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -458,6 +458,10 @@ FactoryGirl.define do
 
   factory :attachment do
     url 'http://foo.link.com'
+
+    trait :with_empty_url do
+      url ''
+    end
   end
 
   factory :transaction do |f|

--- a/spec/models/authorization_document_spec.rb
+++ b/spec/models/authorization_document_spec.rb
@@ -57,4 +57,22 @@ RSpec.describe AuthorizationDocument, type: :model do
       end
     end
   end
+
+  describe ".uploaded?" do
+    let(:authorization_document) { build(:authorization_document, attachment: attachment) }
+
+    subject { authorization_document.uploaded? }
+
+    context "when the attachment is present" do
+      let(:attachment) { build(:attachment, url: 'http://valid.com') }
+
+      it { is_expected.to eq true }
+    end
+
+    context "when the attachment is empty" do
+      let(:attachment) { build(:attachment, url: '') }
+
+      it { is_expected.to eq false }
+    end
+  end
 end

--- a/spec/view_objects/project_documentation_view_object_spec.rb
+++ b/spec/view_objects/project_documentation_view_object_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ProjectDocumentationViewObject do
     end
   end
 
-  describe "#user_bank_accounts" do
+  describe ".user_bank_accounts" do
     let(:project) { build(:project, user: user) }
     let(:project_documentation) { described_class.new(project: project, banks: []) }
 
@@ -58,7 +58,20 @@ RSpec.describe ProjectDocumentationViewObject do
     end
   end
 
-  describe "#user_without_bank_accounts?" do
+  describe ".user_authorization_documents" do
+    let(:user) { create(:user) }
+    let(:project) { build(:project, user: user) }
+    let(:project_documentation) { described_class.new(project: project, banks: []) }
+
+    subject { project_documentation.user_authorization_documents }
+
+    it "returns a list with all the user's authorization_documents" do
+      categories = subject.map { |doc| doc.category.to_sym }
+      expect(categories).to match_array User::LEGAL_ENTITY_AUTHORIZATION_DOCUMENTS
+    end
+  end
+
+  describe ".user_without_bank_accounts?" do
     let(:project) { build(:project, user: user) }
     let(:project_documentation) { described_class.new(project: project, banks: []) }
 
@@ -81,7 +94,7 @@ RSpec.describe ProjectDocumentationViewObject do
     end
   end
 
-  describe "#project_id" do
+  describe ".project_id" do
     let(:project) { double('Project', id: 10, user: build(:user)) }
     let(:project_documentation) { described_class.new(project: project, banks: []) }
 


### PR DESCRIPTION
To give a better feedback to the user, the list of authorization documents is shown on documents tab. Also highlighting the status of each document, whether sent or not.

It is possible to visualize the sent documents clicking on the icon near of the status.

**Demonstration**:

![user_documents](https://cloud.githubusercontent.com/assets/7783787/23775762/153a91c8-0509-11e7-81c5-f5cc1a97d10a.gif)

