### PR TITLE
Showing the associated bank account on project's profile documents tab

### DIFF
--- a/app/assets/javascripts/app/project/bank_account_management.js
+++ b/app/assets/javascripts/app/project/bank_account_management.js
@@ -1,5 +1,5 @@
 App.addChild('BankAccountAssociate', _.extend({
-  el: '#bank-account-associate',
+  el: '.bank-account-associate',
 
   events: {
     'click #new-account': 'showForm',
@@ -37,4 +37,4 @@ App.addChild('BankAccountAssociate', _.extend({
       })
     );
   },
-}, new RemoteRequestsForm($('#bank-account-associate'))));
+}, new RemoteRequestsForm($('.bank-account-associate'))));

--- a/app/assets/stylesheets/juntos_bootstrap/_main.scss
+++ b/app/assets/stylesheets/juntos_bootstrap/_main.scss
@@ -428,6 +428,24 @@ p {
   }
 }
 
+.bank-account-associate {
+  .associated-account {
+    ul {
+      list-style: none;
+      padding: rem-calc(5);
+    }
+
+    li {
+      float: left;
+      margin-bottom: rem-calc(5);
+    }
+
+    span {
+      font-size: $base-font-size;
+    }
+  }
+}
+
 .authorization-documents-list {
   .documents {
     .category {

--- a/app/assets/stylesheets/juntos_bootstrap/abstract/_fonts.scss
+++ b/app/assets/stylesheets/juntos_bootstrap/abstract/_fonts.scss
@@ -6,6 +6,10 @@
   font-size: rem-calc($font-tiny);
 }
 
+.font-default {
+  font-size: rem-calc($base-font-size);
+}
+
 .font-medium {
   font-size: rem-calc($font-medium);
 }

--- a/app/assets/stylesheets/juntos_bootstrap/components/_cards.scss
+++ b/app/assets/stylesheets/juntos_bootstrap/components/_cards.scss
@@ -12,6 +12,19 @@
   &.warning-message {
     border-color: $border-yellow;
   }
+
+  &.secondary {
+    padding: rem-calc(10);
+    background-color: $gray-one;
+
+    h3,
+    h4,
+    p {
+      color: $trout;
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
 }
 
 .card-notification {

--- a/app/decorators/bank_account_decorator.rb
+++ b/app/decorators/bank_account_decorator.rb
@@ -8,4 +8,20 @@ class BankAccountDecorator < Draper::Decorator
   def bank_code
     source.bank.code
   end
+
+  def agency
+    return agency_with_digit if source.agency_digit
+
+    source.agency
+  end
+
+  def account
+    "#{source.account}-#{source.account_digit}"
+  end
+
+  private
+
+  def agency_with_digit
+    "#{source.agency}-#{source.agency_digit}"
+  end
 end

--- a/app/decorators/project_decorator.rb
+++ b/app/decorators/project_decorator.rb
@@ -1,5 +1,6 @@
 class ProjectDecorator < Draper::Decorator
   delegate_all
+  decorates_association :bank_account
   include Draper::LazyHelpers
 
   def remaining_text

--- a/app/view_objects/project_documentation_view_object.rb
+++ b/app/view_objects/project_documentation_view_object.rb
@@ -13,7 +13,11 @@ class ProjectDocumentationViewObject
     )
 
     @banks = banks
-    @project = project
+    @project = project.decorate
+  end
+
+  def associated_bank_account
+    project.bank_account
   end
 
   def user_bank_accounts

--- a/app/views/juntos_bootstrap/projects/bank_accounts/_associate.html.slim
+++ b/app/views/juntos_bootstrap/projects/bank_accounts/_associate.html.slim
@@ -1,4 +1,4 @@
- #bank-account-associate
+ .bank-account-associate
   .w-row
     .w-row
       .w-col.w-col-11.u-text-center
@@ -6,37 +6,41 @@
     .w-row
       .w-col.w-col-11.u-text-center
         p = t('users.bank_accounts.new.subtitle')
-
-  .w-row
-    .w-col.w-col-12
-      .w-row.u-margintop-20
+    - if project_documentation.associated_bank_account
+      .w-row.u-marginbottom-40
+        .w-col.w-col-11
+          = render 'projects/bank_accounts/associated_account', bank_account: project_documentation.associated_bank_account
+    - else
+      .w-row
         .w-col.w-col-12
-          .w-row
+          .w-row.u-margintop-20
             .w-col.w-col-12
-              = simple_form_for :bank_account, url: user_associate_bank_account_with_project_path(project_documentation.user),
-                                method: :put, remote: true,
-                                html: { id: 'associate-project-bank-account', class: 'w-form association-form' } do |form|
-                = form.hidden_field :project_id, value: project_documentation.project_id
-                .w-row
-                  .w-col.w-col-12
-                    label.field-label.bold = t('users.bank_accounts.form.bank_account')
-                .w-row
-                  .w-col.w-col-10
-                    = select_tag :id, options_from_collection_for_select(project_documentation.user_bank_accounts, 'id', 'bank_name'),
-                                      id: 'select-account-id', class: 'select required w-input text-field'
-                    - if project_documentation.user_without_bank_accounts?
-                      span.u-marginbottom-10.font-tiny.label-helper = t('users.bank_accounts.management.notification.no_accounts_registered')
-                  .w-col.w-col-1.u-marginleft-5
-                    a.btn.btn-small.btn-secondary#new-account data-target='#user-bank-account-form'
-                      i.fa.fa-plus.new-account
-                .w-row
-                  .w-col.w-col-4
-                    = form.button :submit, t('users.bank_accounts.form.associate'), id:'association-button',
-                                  class:'btn btn-small', disabled: project_documentation.user_without_bank_accounts?
-                  .w-col.w-col-4.u-marginleft-5
-                    = render 'shared/form_notifications', success: t('users.bank_accounts.new.success'),
-                      fail: t('users.bank_accounts.new.success')
+              .w-row
+                .w-col.w-col-12
+                  = simple_form_for :bank_account, url: user_associate_bank_account_with_project_path(project_documentation.user),
+                                    method: :put, remote: true,
+                                    html: { id: 'associate-project-bank-account', class: 'w-form association-form' } do |form|
+                    = form.hidden_field :project_id, value: project_documentation.project_id
+                    .w-row
+                      .w-col.w-col-12
+                        label.field-label.bold = t('users.bank_accounts.form.bank_account')
+                    .w-row
+                      .w-col.w-col-10
+                        = select_tag :id, options_from_collection_for_select(project_documentation.user_bank_accounts, 'id', 'bank_name'),
+                                          id: 'select-account-id', class: 'select required w-input text-field'
+                        - if project_documentation.user_without_bank_accounts?
+                          span.u-marginbottom-10.font-tiny.label-helper = t('users.bank_accounts.management.notification.no_accounts_registered')
+                      .w-col.w-col-1.u-marginleft-5
+                        a.btn.btn-small.btn-secondary#new-account data-target='#user-bank-account-form'
+                          i.fa.fa-plus.new-account
+                    .w-row
+                      .w-col.w-col-4
+                        = form.button :submit, t('users.bank_accounts.form.associate'), id:'association-button',
+                                      class:'btn btn-small', disabled: project_documentation.user_without_bank_accounts?
+                      .w-col.w-col-4.u-marginleft-5
+                        = render 'shared/form_notifications', success: t('users.bank_accounts.new.success'),
+                          fail: t('users.bank_accounts.new.success')
 
-  .w-row.content.w-hidden
-    .w-col.w-col-12
-      = render '/users/bank_accounts/form', project_documentation: project_documentation
+      .w-row.content.w-hidden
+        .w-col.w-col-12
+          = render '/users/bank_accounts/form', project_documentation: project_documentation

--- a/app/views/juntos_bootstrap/projects/bank_accounts/_associated_account.html.slim
+++ b/app/views/juntos_bootstrap/projects/bank_accounts/_associated_account.html.slim
@@ -1,0 +1,38 @@
+.associated-account.card.secondary
+  .w-row
+    .w-col.w-col-12.u-marginleft-5
+      h3.font-medium.fontweight-semibold
+        = t('users.bank_accounts.management.associated_account.title')
+  .w-row
+    .w-col.w-col-12
+      ul
+        .w-row
+          li.w-col.w-col-12
+            span.fontweight-semibold = "#{Bank.model_name.human}:"
+            span.u-marginleft-5 = bank_account.bank_name
+        .w-row
+          li.w-col.w-col-12
+            span.fontweight-semibold = "#{BankAccount.human_attribute_name(:agency)}:"
+            span.u-marginleft-5 = bank_account.agency
+        .w-row
+          li.w-col.w-col-12
+            span.fontweight-semibold = "#{BankAccount.human_attribute_name(:account)}:"
+            span.u-marginleft-5 = bank_account.account
+        .w-row
+          li.w-col.w-col-12
+            span.fontweight-semibold = "#{BankAccount.human_attribute_name(:owner_name)}:"
+            span.u-marginleft-5 = bank_account.owner_name
+  .w-row.u-marginleft-5
+    .w-col.w-col-12
+      .w-row
+        .w-col.w-col-12
+          p.fontweight-semibold.font-default.u-marginleft-5
+            = t('users.bank_accounts.management.associated_account.documents')
+      .w-row
+        .w-col.w-col-12
+          ul
+            .w-row
+              - bank_account.authorization_documents.each do |document|
+                li.w-col.w-col-12
+                  a.link.default href="#{document.attachment.url}" target="_blank"
+                    = document.category_i18n

--- a/config/locales/catarse_bootstrap/activerecord.en.yml
+++ b/config/locales/catarse_bootstrap/activerecord.en.yml
@@ -18,6 +18,7 @@ en:
           manager_id: 'RG e CPF ou CNH da pessoa responsável pela ONG, o nome da pessoa precisa constar no estatuto ou atas'
   activerecord:
     models:
+      bank: Bank
       channel: 'Channel'
       project: 'Project'
       plan: 'Plan'

--- a/config/locales/catarse_bootstrap/activerecord.pt.yml
+++ b/config/locales/catarse_bootstrap/activerecord.pt.yml
@@ -18,6 +18,7 @@ pt:
           manager_id: 'RG e CPF ou CNH da pessoa responsável pela ONG, o nome da pessoa precisa constar no estatuto ou atas'
   activerecord:
     models:
+      bank: Banco
       channel: Canal
       project: Projeto
       plan: Plano

--- a/config/locales/catarse_bootstrap/views/users/bank_accounts/management.en.yml
+++ b/config/locales/catarse_bootstrap/views/users/bank_accounts/management.en.yml
@@ -4,6 +4,9 @@ en:
       management:
         notification:
           no_accounts_registered: "You don't have registered accounts, click on '+' to add a new account."
+        associated_account:
+          title: 'Associated account:'
+          documents: 'Documents:'
         table:
           bank: 'Bank'
           account: 'Account'

--- a/config/locales/catarse_bootstrap/views/users/bank_accounts/management.pt.yml
+++ b/config/locales/catarse_bootstrap/views/users/bank_accounts/management.pt.yml
@@ -4,6 +4,9 @@ pt:
       management:
         notification:
           no_accounts_registered: "Você não possui nenhuma conta cadastrada, clique no '+' pra adicionar uma conta."
+        associated_account:
+          title: 'Conta associada:'
+          documents: 'Documentos:'
         table:
           bank: 'Banco'
           account: 'Conta'

--- a/db/migrate/20170314173224_add_default_value_to_account_digit.rb
+++ b/db/migrate/20170314173224_add_default_value_to_account_digit.rb
@@ -1,0 +1,5 @@
+class AddDefaultValueToAccountDigit < ActiveRecord::Migration
+  def change
+    change_column_default :bank_accounts, :account_digit, 0
+  end
+end

--- a/spec/decorators/bank_account_decorator_spec.rb
+++ b/spec/decorators/bank_account_decorator_spec.rb
@@ -22,4 +22,34 @@ RSpec.describe BankAccountDecorator do
       expect(subject).to match '1010'
     end
   end
+
+  describe "#agency" do
+    subject { bank_account.agency }
+
+    context "when the agency has a digit" do
+      let(:bank_account) { build(:bank_account, agency: '1111', agency_digit: '11').decorate }
+
+      it "returns the agency number plus the agency digit" do
+        expect(subject).to match '1111-11'
+      end
+    end
+
+    context "when the agency does not have a digit" do
+      let(:bank_account) { build(:bank_account, agency: '1111', agency_digit: nil).decorate }
+
+      it "returns the agency number" do
+        expect(subject).to match '1111'
+      end
+    end
+  end
+
+  describe "#account" do
+    let(:bank_account) { build(:bank_account, account: '2222', account_digit: '22').decorate }
+
+    subject { bank_account.account }
+
+    it "returns the account number plus the account digit" do
+      expect(subject).to match '2222-22'
+    end
+  end
 end

--- a/spec/view_objects/project_documentation_view_object_spec.rb
+++ b/spec/view_objects/project_documentation_view_object_spec.rb
@@ -94,14 +94,38 @@ RSpec.describe ProjectDocumentationViewObject do
     end
   end
 
+  describe ".project" do
+    let(:user) { build(:user) }
+    let(:project) { build(:project, user: user) }
+    let(:project_documentation) { described_class.new(project: project, banks: []) }
+
+    subject { project_documentation.project }
+
+    it { is_expected.to be_decorated }
+  end
+
   describe ".project_id" do
     let(:project) { double('Project', id: 10, user: build(:user)) }
     let(:project_documentation) { described_class.new(project: project, banks: []) }
+
+    before { allow(project).to receive(:decorate).and_return(project) }
 
     subject { project_documentation.project_id }
 
     it "returns the project id" do
       expect(subject).to eq 10
+    end
+  end
+
+  describe ".associated_bank_account" do
+    let(:bank_account) { build(:bank_account) }
+    let(:project) { create(:project, bank_account: bank_account) }
+    let(:project_documentation) { described_class.new(project: project, banks: []) }
+
+    subject { project_documentation.associated_bank_account }
+
+    it "returns the project's bank account" do
+      expect(subject).to eq bank_account
     end
   end
 end


### PR DESCRIPTION
When a project already has an associated bank account, the account details must be shown on the bank account's tab:

<img width="1059" alt="associated_account" src="https://cloud.githubusercontent.com/assets/7783787/23917568/8d8314fc-08ce-11e7-8e49-434b206564a9.png">
