### PR TITLE
Showing the recurring channel's policies for new users

### DIFF
--- a/app/controllers/channels/profiles_controller.rb
+++ b/app/controllers/channels/profiles_controller.rb
@@ -6,6 +6,12 @@ class Channels::ProfilesController < Channels::BaseController
   after_filter :verify_authorized, except: [:how_it_works, :show, :terms, :privacy, :contacts]
   before_action :show_statistics, only: [:show]
 
+  def show
+    if resource.recurring?
+      redirect_to channels_about_path if Channel::RecurringChannelFirstTimeChecker.first_time?(current_user)
+    end
+  end
+
   def edit
     authorize resource
     edit!

--- a/app/services/channel/recurring_channel_first_time_checker.rb
+++ b/app/services/channel/recurring_channel_first_time_checker.rb
@@ -1,0 +1,9 @@
+class Channel::RecurringChannelFirstTimeChecker
+  attr_reader :user
+
+  def self.first_time?(user)
+    return true if user.nil?
+
+    user.projects.none? { |project| project.recurring? }
+  end
+end

--- a/spec/services/channels/recurring_channel_first_time_checker_spec.rb
+++ b/spec/services/channels/recurring_channel_first_time_checker_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Channel::RecurringChannelFirstTimeChecker do
+  describe ".first_time?" do
+    subject { described_class.first_time?(user) }
+
+    context "when there is a user" do
+      context "when the user is owner of a recurring project" do
+        let(:channel) { build(:channel, :recurring) }
+        let(:project) { build(:project, channels: [channel]) }
+        let(:user) { double('User', projects: [project]) }
+
+        it { is_expected.to eq false }
+      end
+
+      context "when the user does not have recurring projects" do
+        let(:user) { double('User', projects: []) }
+
+        it { is_expected.to eq true }
+      end
+    end
+
+    context "when the user does not exists" do
+      let(:user) { nil }
+
+      it { is_expected.to eq true }
+    end
+  end
+end


### PR DESCRIPTION
Was added a hook on the Channel::ProfilesController which redirects users who doesn't have recurring projects for the page of the recurring channel policies, to give a explanation about how this kind of channel works.