### PR TITLE
Allowed the deactivation of recurring plans

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -102,7 +102,7 @@ class ProjectsController < ApplicationController
     @color = (channel.present? && channel.main_color) || @project.color
 
     if @project.recurring?
-      @plans = Plan.all
+      @plans = Plan.active
 
       @project_documentation = ProjectDocumentationViewObject.new(
         banks: Bank.order(:code).to_collection,

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -12,6 +12,8 @@ class Plan < ActiveRecord::Base
 
   has_and_belongs_to_many :projects, join_table: 'projects_plans'
 
+  scope :active, -> { where(active: true) }
+
   def formatted_amount
     amount / 100
   end

--- a/db/migrate/20170317123241_add_active_to_plans.rb
+++ b/db/migrate/20170317123241_add_active_to_plans.rb
@@ -1,0 +1,5 @@
+class AddActiveToPlans < ActiveRecord::Migration
+  def change
+    add_column :plans, :active, :boolean, default: true
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -415,6 +415,10 @@ FactoryGirl.define do
     trait :with_bank_billet do
       payment_methods [:bank_billet]
     end
+
+    trait :inactive do
+      active false
+    end
   end
 
   factory :subscription do |f|

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -33,4 +33,16 @@ RSpec.describe Plan, :type => :model do
       end
     end
   end
+
+  describe "#active" do
+    let(:active_plans) { create_list(:plan, 2) }
+
+    subject { Plan.active }
+
+    before { create(:plan, :inactive) }
+
+    it "returns only the active plans" do
+      expect(subject).to match_array active_plans
+    end
+  end
 end


### PR DESCRIPTION
Filling the lack of the Pagarme's API which doesn't permit delete actions even if the model doesn't have registered associations on the database.