### PR TITLE
Fixed the 'new bank account' button on project's documents tab

### DIFF
--- a/app/assets/javascripts/app/project/bank_account_management.js
+++ b/app/assets/javascripts/app/project/bank_account_management.js
@@ -2,7 +2,7 @@ App.addChild('BankAccountAssociate', _.extend({
   el: '.bank-account-associate',
 
   events: {
-    'click #new-account': 'showForm',
+    'click .new-account': 'showForm',
     'click #close-form':  'hideForm',
     'ajax:success':       'onAjaxPostSuccess',
     'ajax:error':         'onAjaxError',

--- a/app/assets/stylesheets/juntos_bootstrap/_main.scss
+++ b/app/assets/stylesheets/juntos_bootstrap/_main.scss
@@ -444,6 +444,12 @@ p {
       font-size: $base-font-size;
     }
   }
+
+  .new-account {
+    i {
+      pointer-events: none;
+    }
+  }
 }
 
 .authorization-documents-list {

--- a/app/views/juntos_bootstrap/projects/bank_accounts/_associate.html.slim
+++ b/app/views/juntos_bootstrap/projects/bank_accounts/_associate.html.slim
@@ -31,8 +31,8 @@
                         - if project_documentation.user_without_bank_accounts?
                           span.u-marginbottom-10.font-tiny.label-helper = t('users.bank_accounts.management.notification.no_accounts_registered')
                       .w-col.w-col-1.u-marginleft-5
-                        a.btn.btn-small.btn-secondary#new-account data-target='#user-bank-account-form'
-                          i.fa.fa-plus.new-account
+                        a.btn.btn-small.btn-secondary.new-account data-target='#user-bank-account-form'
+                          i.fa.fa-plus
                     .w-row
                       .w-col.w-col-4
                         = form.button :submit, t('users.bank_accounts.form.associate'), id:'association-button',


### PR DESCRIPTION
Now, either the '+' icon or the button itself trigger the event.