### PR TITLE
Fix nil pointer exception on admin channels index

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -29,6 +29,8 @@ class Channel < ActiveRecord::Base
   delegate :display_facebook, :display_twitter, :display_website,
            :submit_your_project_text, :email_image, to: :decorator
 
+  delegate :name_with_locale, to: :category, allow_nil: true, prefix: true
+
   before_save :check_images_url
   after_commit :process_images_async, on: :update
 

--- a/app/views/juntos_bootstrap/admin/channels/index.html.slim
+++ b/app/views/juntos_bootstrap/admin/channels/index.html.slim
@@ -21,6 +21,6 @@ br
         tr class=cycle("even", "odd")
           td= link_to channel.name, root_url(subdomain: channel.permalink)
           td= channel.permalink
-          td= channel.category.name_pt
+          td= channel.category_name_with_locale
           td= link_to t('.edit'), edit_admin_channel_path(channel.id)
   br


### PR DESCRIPTION
The problem is that even if a channel has no category, on index action it tries to call channel.category.name, causing then an error.