### PR TITLE
Adding a validation for the Legal Entity's authorization documents

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -127,7 +127,7 @@ class UserDecorator < Draper::Decorator
   private
 
   def user_documents_div
-    url = h.user_path(h.current_user, anchor: 'settings')
+    text = I18n.t('user_documents_html', scope: 'projects.show')
     css_classes = [
       "fontsize-smaller",
       "fontweight-light",
@@ -136,7 +136,6 @@ class UserDecorator < Draper::Decorator
       "card",
       "card-message"
     ]
-    text = I18n.t('user_documents_html', url: url, scope: 'projects.show')
 
     h.content_tag(:div, text, class: css_classes)
   end

--- a/app/views/juntos_bootstrap/projects/show.html.slim
+++ b/app/views/juntos_bootstrap/projects/show.html.slim
@@ -229,7 +229,6 @@ nav.project-nav.w-hidden-main.w-hidden-medium
               = t(".contribute_project.display_status.#{@project.display_status}", goal: @project.display_goal, date: @project.display_expires_at)
         - if current_user.present? && current_user == @project.user
           = current_user.display_pending_documents
-          = @project.user.decorate.display_project_not_approved
         - unless (%w(bolsasdazmina marcha2016 toddynho asa paranaue jornaljoca projetooca).include? @project.permalink.downcase) || @project.recurring?
           .u-marginbottom-10.w-hidden-small.w-hidden-tiny.project-style= t('.contribution_style')
       .card.card-user.u-marginbottom-10.w-hidden-small.w-hidden-tiny

--- a/config/locales/catarse_bootstrap/views/projects/show.en.yml
+++ b/config/locales/catarse_bootstrap/views/projects/show.en.yml
@@ -163,7 +163,7 @@ en:
       user_documents_html: >
         You do not have the documentation correct yet. This documentation is required
         for the approval of the project . You can send the necessary documentation
-        <a href="%{url}">here</a>.
+        on the 'Required Documentation' tab.
       contribute_project:
         display_status:
           reached_goal: 'This project will be successful and funded at %{date}'

--- a/config/locales/catarse_bootstrap/views/projects/show.pt.yml
+++ b/config/locales/catarse_bootstrap/views/projects/show.pt.yml
@@ -167,7 +167,7 @@ pt:
       user_documents_html: >
         Você ainda não está com a documentação de sua ONG em dia. Esta documentação
         é necessária para a aprovação do projeto. Você pode enviar a documentação
-        necessária <a href="%{url}">aqui</a>
+        necessária na aba 'Documentação Requerida'.
       contribute_project:
         display_status:
           reached_goal: "Este projeto será bem-sucedido e financiado em %{date}"

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -271,48 +271,31 @@ RSpec.describe UserDecorator do
   describe "#display_pending_documents" do
     subject { user.decorate.display_pending_documents }
 
-    context "when user is legal entity" do
-      let(:user) { create(:user, :legal_entity) }
+    before { sign_in user }
 
-      it { is_expected.to be_nil }
+    context "when the user is a legal entity" do
+      let(:user) { build(:user, :legal_entity) }
+
+      context "and does not have pending documents" do
+        before { allow(user).to receive(:pending_documents?).and_return(false) }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "and has pending documents" do
+        before { allow(user).to receive(:pending_documents?).and_return(true) }
+
+        it "returns a div tag with a warning message" do
+          expect(subject)
+            .to have_tag(:div, text: I18n.t('user_documents_html', scope: 'projects.show'))
+        end
+      end
     end
 
-    context "when user is individual" do
-      before { sign_in user }
+    context "when the user is individual" do
+      let(:user) { create(:user, :individual) }
 
-      context "and has no ID document" do
-        let(:user) { create(:user, :without_id_document) }
-
-        it "should be pending documents" do
-          is_expected.to be_kind_of(String)
-        end
-      end
-
-      context "and has no proof of residence" do
-        let(:user) { create(:user, :without_proof_of_residence) }
-
-        it "should be pending documents" do
-          is_expected.to be_kind_of(String)
-        end
-      end
-
-      context "and has ID document" do
-        let(:user) { create(:user, :with_id_document, :without_proof_of_residence) }
-
-        context "but has no proof of residence" do
-          it "should be pending documents" do
-            is_expected.to be_kind_of(String)
-          end
-        end
-
-        context "and has proof of residence" do
-          let(:user) { create(:user, :with_id_document, :with_proof_of_residence) }
-
-          it "should not be pending documents" do
-            is_expected.to be_nil
-          end
-        end
-      end
+      it { is_expected.to be_nil }
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -42,6 +42,17 @@ FactoryGirl.define do
       end
     end
 
+    factory :user_with_legal_entity_authorization_documents do
+      after(:create) do |user|
+        User::LEGAL_ENTITY_AUTHORIZATION_DOCUMENTS.each do |category|
+          user.authorization_documents.build(
+            attributes_for(:user_authorization_document, category: category)
+              .merge({ attachment_attributes: { url: 'http://foo.com' } })
+          )
+        end
+      end
+    end
+
     trait :without_id_document do
       original_doc12_url nil
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -698,4 +698,42 @@ RSpec.describe User, type: :model do
       it { is_expected.to eq([contribution.user]) }
     end
   end
+
+  describe ".pending_documents?" do
+    subject { user.pending_documents? }
+
+    context "when the user is a legal entity" do
+      let(:user) { build(:user, :legal_entity) }
+
+      context "and all the required documents are present" do
+        let(:user) { create(:user_with_legal_entity_authorization_documents, :legal_entity) }
+
+        context "and all documents are valid" do
+          it { is_expected.to eq false }
+        end
+
+        context "and there is an invalid document" do
+          let(:bylaw_registry_document) do
+            user.authorization_documents.find do |document|
+              document.category == 'bylaw_registry'
+            end
+          end
+
+          before { bylaw_registry_document.attachment = build(:attachment, url: '') }
+
+          it { is_expected.to eq true }
+        end
+      end
+
+      context "and there is a document missing" do
+        it { is_expected.to eq true }
+      end
+    end
+
+    context "when the user is individual" do
+      let(:user) { build(:user, :individual) }
+
+      it { is_expected.to eq false }
+    end
+  end
 end


### PR DESCRIPTION
The `.pending_documents?` user's method now is checking if all the required documents were sent by the legal entity.