### PR TITLE
Enabling the pledged value's calculation for recurring projects

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -256,6 +256,8 @@ class Project < ActiveRecord::Base
   end
 
   def pledged
+    return Project::SubscriptionsPledgedValueQuery.call(self) if recurring?
+
     project_total.try(:pledged).to_f
   end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -39,10 +39,11 @@ class Subscription < ActiveRecord::Base
   belongs_to :project
   belongs_to :plan
 
-  scope :charging_day_reached,  -> { waiting_for_charging_day.where(charging_day: DateTime.current.day) }
-  scope :expired,               -> { paid.where("expires_at <= ?", Date.current) }
-  scope :available,             -> { where.not(status: 'waiting_for_charging_day') }
-  scope :by_project,            -> (project_id) { where(project_id: project_id) }
+  scope :charging_day_reached,   -> { waiting_for_charging_day.where(charging_day: Date.current.day) }
+  scope :expired,                -> { paid.where("expires_at <= ?", Date.current) }
+  scope :available,              -> { where.not(status: 'waiting_for_charging_day') }
+  scope :by_project,             -> (project_id) { where(project_id: project_id) }
+  scope :with_paid_transactions, -> { includes(:transactions).where(transactions: { status: Transaction.statuses[:paid] }) }
 
   def self.accepted_charge_options
     {}.tap do |h|

--- a/app/queries/project/subscriptions_pledged_value_query.rb
+++ b/app/queries/project/subscriptions_pledged_value_query.rb
@@ -1,0 +1,17 @@
+class Project::SubscriptionsPledgedValueQuery
+  attr_reader :subscriptions
+
+  def initialize(project)
+    @subscriptions = project.subscriptions.includes(:plan).with_paid_transactions
+  end
+
+  def self.call(project)
+    new(project).call
+  end
+
+  def call
+    subscriptions.inject(0) do |pledged_value, subscription|
+      pledged_value + (subscription.transactions.length * subscription.plan_formatted_amount)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -505,6 +505,34 @@ FactoryGirl.define do
     f.amount 30
     f.payment_method :credit_card
     f.association :subscription, factory: :subscription
+
+    trait :refunded do
+      status :refunded
+    end
+
+    trait :pending_payment do
+      status :pending_payment
+    end
+
+    trait :refused do
+      status :refused
+    end
+
+    trait :processing do
+      status :processing
+    end
+
+    trait :authorized do
+      status :authorized
+    end
+
+    trait :paid do
+      status :paid
+    end
+
+    trait :waiting_payment do
+      status :waiting_payment
+    end
   end
 
   factory :credit_card, class: Hash do |f|

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -149,4 +149,23 @@ RSpec.describe Subscription, type: :model do
       it { is_expected.to be_empty }
     end
   end
+
+  describe ".with_paid_transactions" do
+    let(:subscription_with_paid_transactions) { create(:subscription) }
+    let(:subscription_without_paid_transactions) { create(:subscription) }
+
+    subject { described_class.with_paid_transactions }
+
+    before do
+      [:refunded, :pending_payment, :refused, :processing, :waiting_payment, :authorized].each do |status|
+        create(:transaction, status, subscription: subscription_without_paid_transactions)
+      end
+
+      create(:transaction, :paid, subscription: subscription_with_paid_transactions)
+    end
+
+    it "returns only the subscription's paid transactions" do
+      expect(subject).to contain_exactly subscription_with_paid_transactions
+    end
+  end
 end

--- a/spec/queries/project/subscriptions_pledged_value_query_spec.rb
+++ b/spec/queries/project/subscriptions_pledged_value_query_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe Project::SubscriptionsPledgedValueQuery do
+  describe ".call" do
+    let(:project) { create(:project) }
+
+    before { allow_any_instance_of(Project).to receive(:recurring?).and_return(true) }
+
+    subject { described_class.new(project).call }
+
+    context "when the project has registered subscriptions" do
+      context "with paid transactions" do
+        let(:standard_plan) { create(:plan, amount: 3000, projects: [project]) }
+        let(:premium_plan) { create(:plan, amount: 10000, projects: [project]) }
+        let(:subscritpion_for_standard_plan) { create(:subscription, :paid, plan: standard_plan, project: project) }
+        let(:subscritpion_for_premium_plan) { create(:subscription, :canceled, plan: premium_plan, project: project) }
+
+        before do
+          create(:transaction, status: :paid, subscription: subscritpion_for_standard_plan)
+          create(:transaction, status: :paid, subscription: subscritpion_for_premium_plan)
+          create(:transaction, status: :refunded, subscription: subscritpion_for_standard_plan)
+        end
+
+        it "returns the paid transactions formatted amount" do
+          expect(subject).to eq 130
+        end
+      end
+
+      context "without paid transactions" do
+        let(:plan) { create(:plan, projects: [project]) }
+        let(:subscription) { create(:subscription, :paid, plan: plan, project: project) }
+        let!(:pending_payment_transaction) { create(:transaction, :pending_payment, subscription: subscription) }
+
+        it { is_expected.to be_zero }
+      end
+    end
+
+    context "when the project does not have plans" do
+      let(:project) { create(:project, plans: []) }
+
+      it { is_expected.to be_zero }
+    end
+
+    context "when the project does not have subscriptions" do
+      it "returns zero" do
+        create(:plan, projects: [project])
+
+        is_expected.to be_zero
+      end
+    end
+  end
+end


### PR DESCRIPTION
The Project's `.pledged` method used to calculate only the value coming from contributions, but recurring projects use subscriptions as the donation's mechanism.

This PR aims to calculate this new kind of donation type and show the value at the project profile.