### PR TITLE
Let the project to use the channel's color as default when it is set

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -99,7 +99,6 @@ class ProjectsController < ApplicationController
     @post = resource.posts.where(id: params[:project_post_id]).first if params[:project_post_id].present?
     @contributions = @project.contributions.available_to_count
     @pending_contributions = @project.contributions.with_state(:waiting_confirmation)
-    @color = (channel.present? && channel.main_color) || @project.color
     @project_documentation = ProjectDocumentationViewObject.new(
       banks: Bank.order(:code).to_collection,
       project: @project

--- a/app/decorators/project_decorator.rb
+++ b/app/decorators/project_decorator.rb
@@ -136,7 +136,19 @@ class ProjectDecorator < Draper::Decorator
     source.visible? && source.user == current_user
   end
 
+  def color
+    @color ||= channel_color || category_color || CatarseSettings[:default_color]
+  end
+
   private
+
+  def channel_color
+    source.last_channel.try(:main_color).presence
+  end
+
+  def category_color
+    source.category.try(:color)
+  end
 
   def use_uploaded_image(version)
     source.uploaded_image.send(version).url if source.uploaded_image.present?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,7 +26,7 @@ class Project < ActiveRecord::Base
             :display_image, :display_expires_at, :remaining_text, :time_to_go,
             :display_pledged, :display_goal, :remaining_days, :progress_bar,
             :status_flag, :state_warning_template, :display_card_class,
-            :category_image_url, :display_subgoals, to: :decorator
+            :category_image_url, :display_subgoals, :color, to: :decorator
 
   belongs_to :user
   belongs_to :category
@@ -307,10 +307,6 @@ class Project < ActiveRecord::Base
 
   def recurring?
     channels.one? { |c| c.recurring? }
-  end
-
-  def color
-    recurring? ? CatarseSettings[:default_color] : category.color
   end
 
   def notification_type type

--- a/app/views/juntos_bootstrap/projects/show.html.slim
+++ b/app/views/juntos_bootstrap/projects/show.html.slim
@@ -52,15 +52,15 @@
 nav.project-nav.w-hidden-main.w-hidden-medium
   .w-container.menu-mobile-background
       .w-col.w-col-12.nav.nav-tabs.scroll-tabs.no-padding role="tablist"
-        = link_to '#about', id: 'about_link', class: 'mobile-tab selected active', data: {target: '#project_about.content'}, role: "presentation", style: "background-color: #{@color};"  do
+        = link_to '#about', id: 'about_link', class: 'mobile-tab selected active', data: {target: '#project_about.content'}, role: "presentation", style: "background-color: #{@project.color};"  do
           = t('.menu.about')
-        = link_to '#rewards', id: 'rewards_link', class: 'mobile-tab' , data: {target: '#rewards'}, style: "background-color: #{@color};"  do
+        = link_to '#rewards', id: 'rewards_link', class: 'mobile-tab' , data: {target: '#rewards'}, style: "background-color: #{@project.color};"  do
           => t('.menu.reward')
-        = link_to '#contributions', id: 'contributions_link', class: 'mobile-tab' , data: {target: '#project_contributions'}, style: "background-color: #{@color};"  do
+        = link_to '#contributions', id: 'contributions_link', class: 'mobile-tab' , data: {target: '#project_contributions'}, style: "background-color: #{@project.color};"  do
           => t('.menu.contributions')
           span.badge = project_aumigo ? 4618 :  @project.total_contributions
             |&nbsp;
-        = link_to '#comments', id: 'comments_link', class: ' mobile-tab' , data: {target: '#project_comments'}, style: "background-color: #{@color};"  do
+        = link_to '#comments', id: 'comments_link', class: ' mobile-tab' , data: {target: '#project_comments'}, style: "background-color: #{@project.color};"  do
           => t('.menu.result')
             |&nbsp;
 
@@ -74,23 +74,23 @@ nav.project-nav.w-hidden-main.w-hidden-medium
     .w-container
       .w-row
         .w-col.w-col-9
-          = link_to '#about', id: 'about_link', class: 'nav-tab selected', data: {target: '#project_about.content'}, style: "background-color: #{@color};" do
+          = link_to '#about', id: 'about_link', class: 'nav-tab selected', data: {target: '#project_about.content'}, style: "background-color: #{@project.color};" do
             = t('.menu.about')
-          = link_to '#posts', id: 'posts_link', class: 'nav-tab' , data: {target: '#project_posts'}, style: "background-color: #{@color};" do
+          = link_to '#posts', id: 'posts_link', class: 'nav-tab' , data: {target: '#project_posts'}, style: "background-color: #{@project.color};" do
             => t('.menu.posts')
             span.badge = @posts_count
-          = link_to '#contributions', id: 'contributions_link', class: 'nav-tab' , data: {target: '#project_contributions'}, style: "background-color: #{@color};" do
+          = link_to '#contributions', id: 'contributions_link', class: 'nav-tab' , data: {target: '#project_contributions'}, style: "background-color: #{@project.color};" do
             => t('.menu.contributions')
             span.badge = project_aumigo ? 4618 :  @project.total_contributions
-          = link_to '#comments', id: 'comments_link', class: 'nav-tab' , data: {target: '#project_comments'}, style: "background-color: #{@color};" do
+          = link_to '#comments', id: 'comments_link', class: 'nav-tab' , data: {target: '#project_comments'}, style: "background-color: #{@project.color};" do
             => t('.menu.comments')
             span class="fb-comments-count" data-href="#{request.base_url}/#{@project.permalink}" class="badge" style="display: inline"
               |&nbsp;
           - if policy(@project).update?
-            = link_to '#project_metrics', id: 'project_metrics_link', class: 'nav-tab' , data: {target: '#project_metrics'}, style: "background-color: #{@color};" do
+            = link_to '#project_metrics', id: 'project_metrics_link', class: 'nav-tab' , data: {target: '#project_metrics'}, style: "background-color: #{@project.color};" do
               => t('.menu.metrics')
                 |&nbsp;
-            = link_to '#project_reports', id: 'project_reports_link', class: 'nav-tab' , data: {target: '#project_reports'}, style: "background-color: #{@color};" do
+            = link_to '#project_reports', id: 'project_reports_link', class: 'nav-tab' , data: {target: '#project_reports'}, style: "background-color: #{@project.color};" do
               => t('.menu.reports')
                 |&nbsp;
 
@@ -215,7 +215,7 @@ nav.project-nav.w-hidden-main.w-hidden-medium
           - if project_aumigo
             = link_to t('.contribute_project.submit'), 'http://acaochego.doemaisdoemelhor.org.br/br/doacao/1/acaochego/aumigo-seu-apoio-e-nossa-esperanca', id: 'contribute_project_form', class: "btn bt-yellow btn-large u-marginbottom-20", target: '_blank'
           - else
-            = render 'projects/contributions/link_to_new', project: @project, donate_btn_color: @color
+            = render 'projects/contributions/link_to_new', project: @project, donate_btn_color: @project.color
 
         - if @project.subgoals.empty? && !@project.recurring?
           .fontsize-smaller.fontweight-light.u-marginbottom-30[class=@project.display_card_class]

--- a/spec/decorators/project_decorator_spec.rb
+++ b/spec/decorators/project_decorator_spec.rb
@@ -369,4 +369,51 @@ RSpec.describe ProjectDecorator do
       end
     end
   end
+
+  describe "#color" do
+    before { CatarseSettings[:default_color] = '#ff8a41' }
+
+    context "when the project is within a channel" do
+      context "and the channel's main color has value" do
+        let(:project) { create(:project, channels: [channel]) }
+        let(:channel) { create(:channel, main_color: 'main') }
+
+        it "returns the channel's main color" do
+          expect(project.decorate.color).to eq channel.main_color
+        end
+      end
+
+      context "and the channel's main color is empty" do
+        context "when the project has category" do
+          let(:project)  { create(:project, channels: [channel], category: category) }
+          let(:channel)  { create(:channel, :non_recurring, main_color: '') }
+          let(:category) { create(:category, color: 'c_color') }
+
+          it "returns the category's color" do
+            expect(project.decorate.color).to eq category.color
+          end
+        end
+
+        context "when the project does not have category" do
+          let(:project)       { create(:project, channels: [channel], category: nil) }
+          let(:channel)       { create(:channel, :recurring, main_color: '') }
+          let(:default_color) { CatarseSettings[:default_color] }
+
+          it "should return the default color" do
+            expect(project.decorate.color).to eq default_color
+          end
+        end
+      end
+    end
+
+    context "when the project is not in a channel" do
+      let(:project)        { create(:project, channels: [], category: category) }
+      let(:category)       { create(:category, color: category_color) }
+      let(:category_color) { 'c_color' }
+
+      it "returns the category's color" do
+        expect(project.decorate.color).to eq category_color
+      end
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1936,30 +1936,6 @@ RSpec.describe Project, type: :model do
     end
   end
 
-  describe "#color" do
-    before  { CatarseSettings[:default_color] = '#ff8a41' }
-    subject { project.color }
-
-    context "when a project has a recurring channel" do
-      let(:default_color) { CatarseSettings[:default_color] }
-      let(:channel)       { create :channel, recurring: true }
-      let(:project)       { create :project, channels: [channel] }
-
-      it "should return the default color" do
-        is_expected.to eq(default_color)
-      end
-    end
-
-    context "when a project is not related to a recurring channel" do
-      let(:category) { create :category }
-      let(:project)  { create :project, category: category }
-
-      it "should return the category color" do
-        is_expected.to eq category.color
-      end
-    end
-  end
-
   describe "#notification_type" do
     subject { project.notification_type(:foo) }
 


### PR DESCRIPTION
When the project is linked to a channel, it should use the channel's main color as default. If it's empty or the project has no channel, use the project's color instead.