### PR TITLE
Fixed the donators count on recurring projects' profile page

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -97,7 +97,6 @@ class ProjectsController < ApplicationController
     @channel = resource.channels.first
     @posts_count = resource.posts.count(:all)
     @post = resource.posts.where(id: params[:project_post_id]).first if params[:project_post_id].present?
-    @contributions = @project.contributions.available_to_count
     @pending_contributions = @project.contributions.with_state(:waiting_confirmation)
     @color = (channel.present? && channel.main_color) || @project.color
     @project_documentation = ProjectDocumentationViewObject.new(
@@ -108,6 +107,9 @@ class ProjectsController < ApplicationController
     if @project.recurring?
       @plans = Plan.active
       @last_subscription_report = @project.subscription_reports.try(:last)
+      @supporters = User.with_paid_transactions_for_project(@project.id)
+    else
+      @contributions = @project.contributions.available_to_count
     end
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -262,6 +262,8 @@ class Project < ActiveRecord::Base
   end
 
   def total_contributions
+    return User.with_paid_transactions_for_project(id).count if recurring?
+
     project_total.try(:total_contributions).to_i
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -105,15 +105,23 @@ class User < ActiveRecord::Base
 
     where.not(id: user_ids)
   end
+
   scope :already_used_credits, -> do
     user_ids = Contribution.credits.confirmed_state.select(:user_id)
 
     has_credits.where(id: user_ids)
   end
+
   scope :has_not_used_credits_last_month, -> do
     user_ids = Contribution.credits.confirmed_state.where("created_at < ?", 1.month.ago).select(:user_id)
 
     has_credits.where(id: user_ids)
+  end
+
+  scope :with_paid_transactions_for_project, -> (project_id) do
+    joins(recurring_contributions: :transactions)
+      .where(subscriptions: { project_id: project_id })
+      .where(transactions: { status: Transaction.statuses[:paid] })
   end
 
   def send_credits_notification

--- a/app/views/juntos_bootstrap/projects/contributions/_contribution.html.slim
+++ b/app/views/juntos_bootstrap/projects/contributions/_contribution.html.slim
@@ -3,27 +3,4 @@
     = link_to '#', title: t('projects.contributions.contribution.anonymous_contribution') do
       .contribution-thumb.u-left[style="background-image: url('#{asset_url('user.png')}'); background-size: cover; background-position: center;"]
 - else
-  .contribution.u-margintop-10
-    = link_to user_path(contribution.user), title: contribution.user.name do
-      .contribution-thumb.u-left[style="background-image: url('#{contribution.user.decorate.display_image}'); background-size: cover; background-position: center;"]
-/- if contribution.anonymous
-  /.w-clearfix.u-marginbottom-20
-
-    /.thumb.u-left.u-round[style="background-image: url('#{asset_url('user.png')}'); background-size: contain;"]
-
-    /.fontsize-base.fontweight-semibold
-      /| Apoiador Anônimo
-    /.fontsize-smaller = l(contribution.confirmed_at || contribution.created_at, format: :simple)
-  /.divider.u-marginbottom-20
-/- else
-  /.w-clearfix.u-marginbottom-20
-
-    /= link_to user_path(contribution.user) do
-      /.thumb.u-left.u-round[style="background-image: url('#{contribution.user.display_image}'); background-size: contain;"]
-
-    /.fontsize-base.fontweight-semibold
-      /= link_to user_path(contribution.user), class: 'link-hidden-dark' do
-        /= contribution.user.short_name
-    /.fontsize-smaller = l(contribution.confirmed_at || contribution.created_at, format: :simple)
-    /.fontsize-smaller = contribution.user.contributions_text
-  /.divider.u-marginbottom-20
+  = render 'projects/supporters/card', supporter: contribution.user

--- a/app/views/juntos_bootstrap/projects/contributions/_pending.html.slim
+++ b/app/views/juntos_bootstrap/projects/contributions/_pending.html.slim
@@ -1,0 +1,14 @@
+.w-row
+  .w-col.w-col-small-6.w-col-tiny-6
+  br/
+  br/
+
+  .w-hidden-small.w-hidden-tiny
+    h1 = t('.title')
+  .w-hidden-main.w-hidden-medium
+    h1.align-center.total-supporters = t('.title')
+  = render pending_contributions
+.divider.u-marginbottom-20
+.results
+| &nbsp;
+#contributions-loading.loader.u-text-center.w-col.w-col-12 = image_tag "loading.gif"

--- a/app/views/juntos_bootstrap/projects/show.html.slim
+++ b/app/views/juntos_bootstrap/projects/show.html.slim
@@ -180,31 +180,11 @@ nav.project-nav.w-hidden-main.w-hidden-medium
         = javascript_include_tag "//www.google.com/jsapi", "chartkick"
       #project_reports.content.w-hidden
         = render 'dashboard_reports'
-
-
       #project_posts.content.w-col.w-col-8.w-hidden
         = render 'dashboard_posts'
       #project_contributions.content.w-col.w-col-8.w-hidden
-        .w-row
-          .w-hidden-main.w-hidden-medium
-            h1.align-center.total-supporters
-              = "#{@project.total_contributions} #{t('.supporters')}"
-          = render @contributions
-        - if policy(@project).update?
-          .w-row
-            .w-col.w-col-small-6.w-col-tiny-6
-            br/
-            br/
-
-            .w-hidden-small.w-hidden-tiny
-              h1 = t('.pending_contributions')
-            .w-hidden-main.w-hidden-medium
-              h1.align-center.total-supporters = t('.pending_contributions')
-            = render @pending_contributions
-          .divider.u-marginbottom-20
-        .results
-          | &nbsp;
-        #contributions-loading.loader.u-text-center.w-col.w-col-12 = image_tag "loading.gif"
+        = render 'projects/supporters/list', project: @project, supporters: @supporters, contributions: @contributions
+        = render 'projects/contributions/pending', pending_contributions: @pending_contributions if policy(@project).update?
 
       #project_comments.content.w-col.w-col-8.w-hidden
 

--- a/app/views/juntos_bootstrap/projects/supporters/_card.html.slim
+++ b/app/views/juntos_bootstrap/projects/supporters/_card.html.slim
@@ -1,0 +1,3 @@
+.contribution.u-margintop-10
+  = link_to user_path(supporter), title: supporter.name do
+    .contribution-thumb.u-left[style="background-image: url('#{supporter.decorate.display_image}'); background-size: cover; background-position: center;"]

--- a/app/views/juntos_bootstrap/projects/supporters/_list.html.slim
+++ b/app/views/juntos_bootstrap/projects/supporters/_list.html.slim
@@ -1,0 +1,9 @@
+.w-row
+  .w-hidden-main.w-hidden-medium
+    h1.align-center.total-supporters
+      = "#{project.total_contributions} #{t('.title')}"
+  - if project.recurring?
+    - supporters.each do |supporter|
+      = render 'projects/supporters/card', supporter: supporter
+  - else
+    = render contributions

--- a/config/locales/catarse_bootstrap/views/projects/show.en.yml
+++ b/config/locales/catarse_bootstrap/views/projects/show.en.yml
@@ -1,5 +1,11 @@
 en:
   projects:
+    supporters:
+      list:
+        title: 'Supporters'
+    contributions:
+      pending:
+        title: 'Pending contributions'
     dashboard_project:
       start: 'Tell what you have to say to the world!'
       start_subtitle: 'Use the space below to tell us about your project and why people should get carried away with it and embrace your idea'

--- a/config/locales/catarse_bootstrap/views/projects/show.pt.yml
+++ b/config/locales/catarse_bootstrap/views/projects/show.pt.yml
@@ -1,5 +1,11 @@
 pt:
   projects:
+    supporters:
+      list:
+        title: 'Apoiadores'
+    contributions:
+      pending:
+        title: 'Contribuições pendentes'
     dashboard_project:
       start: "Conte o que você tem a dizer para o mundo!"
       start_subtitle: "Use esse espaço abaixo para contar sobre seu projeto e o porquê as pessoas deveriam se empolgar com ele e abraçar sua ideia"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -442,6 +442,20 @@ FactoryGirl.define do
     f.association :plan, factory: :plan
     f.association :user, factory: :user
 
+    factory :subscription_with_paid_transaction do
+      after(:create) do |subscription|
+        create(:transaction, :paid, subscription: subscription)
+      end
+    end
+
+    factory :subscription_without_paid_transactions do
+      after(:create) do |subscription|
+        [:refunded, :pending_payment, :refused, :processing, :waiting_payment, :authorized].each do |status|
+          create(:transaction, status, subscription: subscription)
+        end
+      end
+    end
+
     trait :bank_billet_payment do
       payment_method 'bank_billet'
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1630,32 +1630,44 @@ RSpec.describe Project, type: :model do
   describe "#total_contributions" do
     subject { project.total_contributions }
 
-    context "when there are no contributions for the project" do
-      it { is_expected.to be_zero }
+    context "when it is a recurring project" do
+      before { allow(project).to receive(:recurring?).and_return(true) }
+
+      it "counts all users whose have a paid transaction for the project" do
+        expect(User).to receive_message_chain(:with_paid_transactions_for_project, :count)
+
+        subject
+      end
     end
 
-    context "when there are contributions for the project" do
-      context "and the contribution state is valid" do
-        before do
-          create(:contribution, :confirmed, project: project)
-          create(:contribution, :requested_refund, project: project)
-        end
-
-        it { is_expected.to eq(2) }
+    context "when it is not a recurring project" do
+      context "when there are no contributions for the project" do
+        it { is_expected.to be_zero }
       end
 
-      context "and the contribution state is invalid" do
-        before do
-          create(:contribution, :pending, project_value: 100, project: project)
-          create(:contribution, :canceled, project_value: 100, project: project)
-          create(:contribution, :refunded, project_value: 100, project: project)
-          create(:contribution, :deleted, project_value: 100, project: project)
-          create(:contribution, :invalid_payment, project_value: 100, project: project)
-          create(:contribution, :waiting_confirmation, project_value: 100, project: project)
-          create(:contribution, :refunded_and_canceled, project_value: 100, project: project)
+      context "when there are contributions for the project" do
+        context "and the contribution state is valid" do
+          before do
+            create(:contribution, :confirmed, project: project)
+            create(:contribution, :requested_refund, project: project)
+          end
+
+          it { is_expected.to eq(2) }
         end
 
-        it { is_expected.to be_zero }
+        context "and the contribution state is invalid" do
+          before do
+            create(:contribution, :pending, project_value: 100, project: project)
+            create(:contribution, :canceled, project_value: 100, project: project)
+            create(:contribution, :refunded, project_value: 100, project: project)
+            create(:contribution, :deleted, project_value: 100, project: project)
+            create(:contribution, :invalid_payment, project_value: 100, project: project)
+            create(:contribution, :waiting_confirmation, project_value: 100, project: project)
+            create(:contribution, :refunded_and_canceled, project_value: 100, project: project)
+          end
+
+          it { is_expected.to be_zero }
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -736,4 +736,27 @@ RSpec.describe User, type: :model do
       it { is_expected.to eq false }
     end
   end
+
+  describe ".with_paid_transactions_for_project" do
+    let(:project) { create(:project) }
+
+    subject { User.with_paid_transactions_for_project(project.id) }
+
+    context "when the project has subscribers" do
+      let(:john) { create(:user) }
+
+      before do
+        create(:subscription_with_paid_transaction, project: project, user: john)
+        create(:subscription_without_paid_transactions, project: project)
+      end
+
+      it "returns only the subscribers with paid transactions" do
+        expect(subject).to contain_exactly john
+      end
+    end
+
+    context "when the project does not have subscribers" do
+      it { is_expected.to be_empty }
+    end
+  end
 end


### PR DESCRIPTION
The donators count was still based exclusively on the Contribution model. So, when some user make a subscription for a recurring project, this donation is not count. Now, the project's method `.total_contributions` searches for users with paid transactions when the project is recurring.