### PR TITLE
Saving the bank billet url for subscriptions paid with bank billet

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -57,6 +57,10 @@ class Subscription < ActiveRecord::Base
     !canceled?
   end
 
+  def current_transaction
+    transactions.find_by(current: true)
+  end
+
   private
 
   def permitted_payment_methods

--- a/app/services/recurring_contribution/subscriptions/update_juntos.rb
+++ b/app/services/recurring_contribution/subscriptions/update_juntos.rb
@@ -35,10 +35,16 @@ class RecurringContribution::Subscriptions::UpdateJuntos
     transaction = Transaction.new(
       transaction_code: pagarme_subscription.current_transaction.id,
       status:           pagarme_subscription.current_transaction.status,
-      amount:           pagarme_subscription.current_transaction.amount
+      amount:           pagarme_subscription.current_transaction.amount,
+      bank_billet_url:  bank_billet_url,
+      current:          true
     )
 
     juntos_subscription.transactions << transaction
+  end
+
+  def bank_billet_url
+    juntos_subscription.bank_billet? ? pagarme_subscription.current_transaction.boleto_url : ''
   end
 
   def valid_pagarme_subscription?

--- a/db/migrate/20170405192543_add_bank_billet_url_to_transactions.rb
+++ b/db/migrate/20170405192543_add_bank_billet_url_to_transactions.rb
@@ -1,0 +1,5 @@
+class AddBankBilletUrlToTransactions < ActiveRecord::Migration
+  def change
+    add_column :transactions, :bank_billet_url, :string, default: ''
+  end
+end

--- a/db/migrate/20170405193817_add_current_to_transactions.rb
+++ b/db/migrate/20170405193817_add_current_to_transactions.rb
@@ -1,0 +1,5 @@
+class AddCurrentToTransactions < ActiveRecord::Migration
+  def change
+    add_column :transactions, :current, :boolean, default: false
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -168,4 +168,29 @@ RSpec.describe Subscription, type: :model do
       expect(subject).to contain_exactly subscription_with_paid_transactions
     end
   end
+
+  describe ".current_transaction" do
+    let(:subscription) { create(:subscription) }
+
+    subject { subscription.current_transaction }
+
+    context "when the subscription has transactions" do
+      let!(:transaction) { create(:transaction, subscription: subscription) }
+
+      context "and there is a current transaction" do
+        it "returns the current transaction" do
+          current_transaction = create(:transaction, current: true, subscription: subscription)
+          expect(subject).to eq current_transaction
+        end
+      end
+
+      context "and there is no current transaction" do
+        it { is_expected.to be_nil }
+      end
+    end
+
+    context "when the subscription does not have transactions" do
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/services/recurring_contribution/transactions/find_or_create_spec.rb
+++ b/spec/services/recurring_contribution/transactions/find_or_create_spec.rb
@@ -21,6 +21,20 @@ RSpec.describe RecurringContribution::Transactions::FindOrCreate do
         allow(Pagarme::API).to receive(:find_transaction).and_return(transaction)
       end
 
+      context "and the transaction's subscription has a current transaction" do
+        let!(:latest_current_transaction) { create(:transaction, current: true, subscription: subscription) }
+
+        it "sets the current attribute value of that transaction to false" do
+          subject
+          expect(latest_current_transaction.reload).to_not be_current
+        end
+
+        it "creates the new transaction with true as the current attribute value" do
+          subject
+          expect(created_transaction).to be_current
+        end
+      end
+
       it { is_expected.to eq(created_transaction) }
 
       it "should have called the Transaction create method" do

--- a/spec/support/recurring_contributions_helper.rb
+++ b/spec/support/recurring_contributions_helper.rb
@@ -16,11 +16,12 @@ module RecurringContributionsHelper
                    trial_days: trial_days)
   end
 
-  def build_transaction_mock(subscription_id = nil, id: 10)
+  def build_transaction_mock(subscription_id = nil, id: 10, boleto_url: '')
     double("Transaction", id: id,
                           status: 'waiting_payment',
                           amount: '31000',
                           payment_method: 'credit_card',
+                          boleto_url: boleto_url,
                           subscription_id: subscription_id)
 
   end


### PR DESCRIPTION
Now, when a subscription is created with the bank billet payment method, the url for the bank billet generated by pagarme is saved on the transaction model.