### PR TITLE
Allow nil for cpf field for non-Brazilians

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -16,7 +16,7 @@ class Subscription < ActiveRecord::Base
   validates_presence_of :status, :payment_method, :charging_day,
                         :plan_id, :user_id, :project_id
 
-  validates_presence_of :donator_cpf, on: :create
+  validates_presence_of :donator_cpf, on: :create, if: :portuguese_language?
 
   validates_inclusion_of :payment_method, in: 'permitted_payment_methods',
                                           unless: 'plan.nil?'
@@ -61,5 +61,9 @@ class Subscription < ActiveRecord::Base
 
   def permitted_payment_methods
     plan.payment_methods
+  end
+
+  def portuguese_language?
+    I18n.locale.to_s == "pt"
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -25,7 +25,18 @@ RSpec.describe Subscription, type: :model do
     it { is_expected.to validate_presence_of(:plan_id) }
     it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.to validate_presence_of(:project_id) }
-    it { is_expected.to validate_presence_of(:donator_cpf).on(:create) }
+
+    context "when the locale is Portuguese" do
+      before { I18n.locale = :pt }
+
+      it { is_expected.to validate_presence_of(:donator_cpf).on(:create) }
+    end
+
+    context "when the locale is English" do
+      before { I18n.locale = :en }
+
+      it { is_expected.not_to validate_presence_of(:donator_cpf) }
+    end
 
     it { is_expected.not_to allow_value(0).for(:charging_day) }
     it { is_expected.not_to allow_value(32).for(:charging_day) }


### PR DESCRIPTION
When the contribution is being created using English as language, the `cpf` field should allow blank. When the contribution is being created using Portuguese as language, the `cpf` field should not allow blank.