### PR TITLE
Calculate the recurring project's pledged value using the paid subscriptions for the current month only

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -106,7 +106,7 @@ class ProjectsController < ApplicationController
     if @project.recurring?
       @plans = Plan.active
       @last_subscription_report = @project.subscription_reports.try(:last)
-      @supporters = User.with_paid_transactions_for_project(@project.id)
+      @supporters = User.with_paid_subscriptions_for_project(@project.id)
     else
       @contributions = @project.contributions.available_to_count
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -262,7 +262,7 @@ class Project < ActiveRecord::Base
   end
 
   def total_contributions
-    return User.with_paid_transactions_for_project(id).count if recurring?
+    return User.with_paid_subscriptions_for_project(id).count if recurring?
 
     project_total.try(:total_contributions).to_i
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -39,11 +39,10 @@ class Subscription < ActiveRecord::Base
   belongs_to :project
   belongs_to :plan
 
-  scope :charging_day_reached,   -> { waiting_for_charging_day.where(charging_day: Date.current.day) }
-  scope :expired,                -> { paid.where("expires_at <= ?", Date.current) }
-  scope :available,              -> { where.not(status: 'waiting_for_charging_day') }
-  scope :by_project,             -> (project_id) { where(project_id: project_id) }
-  scope :with_paid_transactions, -> { includes(:transactions).where(transactions: { status: Transaction.statuses[:paid] }) }
+  scope :charging_day_reached, -> { waiting_for_charging_day.where(charging_day: Date.current.day) }
+  scope :expired,              -> { paid.where("expires_at <= ?", Date.current) }
+  scope :available,            -> { where.not(status: 'waiting_for_charging_day') }
+  scope :by_project,           -> (project_id) { where(project_id: project_id) }
 
   def self.accepted_charge_options
     {}.tap do |h|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -118,10 +118,12 @@ class User < ActiveRecord::Base
     has_credits.where(id: user_ids)
   end
 
-  scope :with_paid_transactions_for_project, -> (project_id) do
-    joins(recurring_contributions: :transactions)
-      .where(subscriptions: { project_id: project_id })
-      .where(transactions: { status: Transaction.statuses[:paid] })
+  scope :with_paid_subscriptions_for_project, -> (project_id) do
+    joins(:recurring_contributions).where(
+      subscriptions: {
+        project_id: project_id,
+        status: Subscription.statuses[:paid]
+      })
   end
 
   def send_credits_notification

--- a/app/queries/project/subscriptions_pledged_value_query.rb
+++ b/app/queries/project/subscriptions_pledged_value_query.rb
@@ -2,7 +2,7 @@ class Project::SubscriptionsPledgedValueQuery
   attr_reader :subscriptions
 
   def initialize(project)
-    @subscriptions = project.subscriptions.includes(:plan).with_paid_transactions
+    @subscriptions = project.subscriptions.paid.includes(:plan)
   end
 
   def self.call(project)
@@ -10,8 +10,6 @@ class Project::SubscriptionsPledgedValueQuery
   end
 
   def call
-    subscriptions.inject(0) do |pledged_value, subscription|
-      pledged_value + (subscription.transactions.length * subscription.plan_formatted_amount)
-    end
+    subscriptions.map(&:plan_formatted_amount).sum
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1634,7 +1634,7 @@ RSpec.describe Project, type: :model do
       before { allow(project).to receive(:recurring?).and_return(true) }
 
       it "counts all users whose have a paid transaction for the project" do
-        expect(User).to receive_message_chain(:with_paid_transactions_for_project, :count)
+        expect(User).to receive_message_chain(:with_paid_subscriptions_for_project, :count)
 
         subject
       end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -161,25 +161,6 @@ RSpec.describe Subscription, type: :model do
     end
   end
 
-  describe ".with_paid_transactions" do
-    let(:subscription_with_paid_transactions) { create(:subscription) }
-    let(:subscription_without_paid_transactions) { create(:subscription) }
-
-    subject { described_class.with_paid_transactions }
-
-    before do
-      [:refunded, :pending_payment, :refused, :processing, :waiting_payment, :authorized].each do |status|
-        create(:transaction, status, subscription: subscription_without_paid_transactions)
-      end
-
-      create(:transaction, :paid, subscription: subscription_with_paid_transactions)
-    end
-
-    it "returns only the subscription's paid transactions" do
-      expect(subject).to contain_exactly subscription_with_paid_transactions
-    end
-  end
-
   describe ".current_transaction" do
     let(:subscription) { create(:subscription) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -737,25 +737,32 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe ".with_paid_transactions_for_project" do
+  describe ".with_paid_subscriptions_for_project" do
     let(:project) { create(:project) }
 
-    subject { User.with_paid_transactions_for_project(project.id) }
+    subject { User.with_paid_subscriptions_for_project(project.id).map(&:name) }
 
-    context "when the project has subscribers" do
-      let(:john) { create(:user) }
-
+    context "when there are subscribers with paid subscriptions" do
       before do
-        create(:subscription_with_paid_transaction, project: project, user: john)
-        create(:subscription_without_paid_transactions, project: project)
+        user_1 = create(:user, name: 'subscriber_1')
+        user_2 = create(:user, name: 'subscriber_2')
+
+        create(:subscription, :paid, project: project, user: user_1)
+        create(:subscription, :paid, project: project, user: user_2)
       end
 
-      it "returns only the subscribers with paid transactions" do
-        expect(subject).to contain_exactly john
+      it "returns the subscribers with paid subscriptions" do
+        is_expected.to contain_exactly 'subscriber_1', 'subscriber_2'
       end
     end
 
-    context "when the project does not have subscribers" do
+    context "when there are no subscribers with paid subscriptions" do
+      before do
+        %i(unpaid pending_payment canceled).each do |status|
+          create(:subscription, status, project: project)
+        end
+      end
+
       it { is_expected.to be_empty }
     end
   end

--- a/spec/queries/project/subscriptions_pledged_value_query_spec.rb
+++ b/spec/queries/project/subscriptions_pledged_value_query_spec.rb
@@ -8,43 +8,19 @@ RSpec.describe Project::SubscriptionsPledgedValueQuery do
 
     subject { described_class.new(project).call }
 
-    context "when the project has registered subscriptions" do
-      context "with paid transactions" do
-        let(:standard_plan) { create(:plan, amount: 3000, projects: [project]) }
-        let(:premium_plan) { create(:plan, amount: 10000, projects: [project]) }
-        let(:subscritpion_for_standard_plan) { create(:subscription, :paid, plan: standard_plan, project: project) }
-        let(:subscritpion_for_premium_plan) { create(:subscription, :canceled, plan: premium_plan, project: project) }
-
-        before do
-          create(:transaction, status: :paid, subscription: subscritpion_for_standard_plan)
-          create(:transaction, status: :paid, subscription: subscritpion_for_premium_plan)
-          create(:transaction, status: :refunded, subscription: subscritpion_for_standard_plan)
-        end
-
-        it "returns the paid transactions formatted amount" do
-          expect(subject).to eq 130
-        end
+    context "when the project has subscriptions" do
+      before do
+        plan_30 = create(:plan, amount: 3000)
+        create_list(:subscription, 4, :paid, plan: plan_30, project: project)
       end
 
-      context "without paid transactions" do
-        let(:plan) { create(:plan, projects: [project]) }
-        let(:subscription) { create(:subscription, :paid, plan: plan, project: project) }
-        let!(:pending_payment_transaction) { create(:transaction, :pending_payment, subscription: subscription) }
-
-        it { is_expected.to be_zero }
+      it "returns the subscriptions formatted amount" do
+        expect(subject).to eq 120
       end
-    end
-
-    context "when the project does not have plans" do
-      let(:project) { create(:project, plans: []) }
-
-      it { is_expected.to be_zero }
     end
 
     context "when the project does not have subscriptions" do
       it "returns zero" do
-        create(:plan, projects: [project])
-
         is_expected.to be_zero
       end
     end


### PR DESCRIPTION
It does not need to display the hole pledged value for recurring projects. The pledged value should only be calculated for the current month.