### PR TITLE
Updated the 'subscriptions/new' view

### DIFF
--- a/app/views/juntos_bootstrap/projects/subscriptions/new.html.slim
+++ b/app/views/juntos_bootstrap/projects/subscriptions/new.html.slim
@@ -31,7 +31,10 @@
                 h4 = t('.form.cpf')
             .w-row
               .w-col.w-col-12.w-col-tiny-12
-                = form.input_field :donator_cpf, value: current_user.cpf, class: 'u-marginbottom-5 positive w-input'
+                = form.input_field :donator_cpf, value: current_user.cpf, class: 'positive w-input postfix'
+            .w-row.u-margintop-40
+              .w-col.w-col-12.w-col-tiny-12
+                span.font-tiny.label-helper = t('.form.cpf_observation') if I18n.locale == :en
           .w-row
             .w-col.w-col-12.user-payment-preferences
               h3 = t('.user_preferences')

--- a/config/locales/catarse_bootstrap/views/projects/subscriptions.en.yml
+++ b/config/locales/catarse_bootstrap/views/projects/subscriptions.en.yml
@@ -25,6 +25,7 @@ en:
           card_expiration_year: 'Expiration year:'
           card_expiration_cvv: 'Security code'
           cpf: 'CPF'
+          cpf_observation: '* Required for Brazilians only'
           charging_day: "When do you wish to start contributing?"
           charging_day_observation: "* Your contributions will be done every 30 days (one month)."
           expires_at: 'How many months would you like to donate?'

--- a/config/locales/catarse_bootstrap/views/projects/subscriptions.pt.yml
+++ b/config/locales/catarse_bootstrap/views/projects/subscriptions.pt.yml
@@ -25,6 +25,7 @@ pt:
           card_expiration_year: 'Ano de expiração:'
           card_expiration_cvv: 'Código de segurança:'
           cpf: 'CPF'
+          cpf_observation: '* Obrigatório apenas para brasileiros'
           charging_day: 'Qual o melhor dia para realizar sua primeira contribuição?'
           charging_day_observation: '* Suas contribuições serão realizadas a cada 30 dias (1 mês).'
           expires_at: 'Por quantos meses você gostaria de doar?'


### PR DESCRIPTION
adding an observation on the form's cpf field, remembering foreign users that this field is required only for Brazilians.